### PR TITLE
Twitter adapter and sample added

### DIFF
--- a/Bot.Builder.Community.Samples.sln
+++ b/Bot.Builder.Community.Samples.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChoiceFlow Dialog Sample", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cortana Assistant Alexa Sample", "samples\Cortana Assistant Alexa Sample\Cortana Assistant Alexa Sample.csproj", "{2FD06287-25A1-47A6-BB85-2E508E543E66}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Twitter Adapter Sample", "samples\Twitter Adapter Sample\Twitter Adapter Sample.csproj", "{036E2C3A-6894-4237-99B7-591D16326602}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{2FD06287-25A1-47A6-BB85-2E508E543E66}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FD06287-25A1-47A6-BB85-2E508E543E66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FD06287-25A1-47A6-BB85-2E508E543E66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{036E2C3A-6894-4237-99B7-591D16326602}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{036E2C3A-6894-4237-99B7-591D16326602}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{036E2C3A-6894-4237-99B7-591D16326602}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{036E2C3A-6894-4237-99B7-591D16326602}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Bot.Builder.Community.sln
+++ b/Bot.Builder.Community.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28315.86
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.329
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{57D9879A-FC9F-468C-B86F-BE45A1472F88}"
 EndProject
@@ -60,6 +60,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bot.Builder.Community.Adapters.Google", "libraries\Bot.Builder.Community.Adapters.Google\Bot.Builder.Community.Adapters.Google.csproj", "{2CCB1E5E-A4B5-46FA-B38D-5C5CA04A2CD3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bot.Builder.Community.Storage.EntityFramework", "libraries\Bot.Builder.Community.Storage.EntityFramework\Bot.Builder.Community.Storage.EntityFramework.csproj", "{1EF09D96-D5EB-4445-8369-E87A7A59FA93}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bot.Builder.Community.Adapters.Twitter", "libraries\Bot.Builder.Community.Adapters.Twitter\Bot.Builder.Community.Adapters.Twitter.csproj", "{06CECA83-4578-467E-80DD-66C4D0526B9D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -219,6 +221,14 @@ Global
 		{1EF09D96-D5EB-4445-8369-E87A7A59FA93}.Documentation|Any CPU.Build.0 = Debug|Any CPU
 		{1EF09D96-D5EB-4445-8369-E87A7A59FA93}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1EF09D96-D5EB-4445-8369-E87A7A59FA93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06CECA83-4578-467E-80DD-66C4D0526B9D}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{06CECA83-4578-467E-80DD-66C4D0526B9D}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{06CECA83-4578-467E-80DD-66C4D0526B9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06CECA83-4578-467E-80DD-66C4D0526B9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06CECA83-4578-467E-80DD-66C4D0526B9D}.Documentation|Any CPU.ActiveCfg = Debug|Any CPU
+		{06CECA83-4578-467E-80DD-66C4D0526B9D}.Documentation|Any CPU.Build.0 = Debug|Any CPU
+		{06CECA83-4578-467E-80DD-66C4D0526B9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06CECA83-4578-467E-80DD-66C4D0526B9D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -248,6 +258,7 @@ Global
 		{11CFD052-F4E5-44F0-AD19-98FF648C7613} = {08759E28-8592-4EBA-9A07-19A5BED3FB0C}
 		{2CCB1E5E-A4B5-46FA-B38D-5C5CA04A2CD3} = {BF310E8A-8DA1-441F-90E9-DE0E66553048}
 		{1EF09D96-D5EB-4445-8369-E87A7A59FA93} = {DC62D60A-2EA2-4DB1-B1BA-C8F38D3940B3}
+		{06CECA83-4578-467E-80DD-66C4D0526B9D} = {BF310E8A-8DA1-441F-90E9-DE0E66553048}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9FE3B75E-BA2B-45BC-BBF0-DDA8BA10C4F0}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/ActivityExtensions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/ActivityExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Microsoft.Bot.Schema;
+
+namespace Bot.Builder.Community.Adapters.Twitter
+{
+    public static class ActivityExtensions
+    {
+        public static NewDirectMessageObject AsTwitterMessage(this Activity activity)
+        {
+            if (string.IsNullOrEmpty(activity.Text))
+            {
+                throw new TwitterException("You can't send an empty message.");
+            }
+
+            if (activity.Text.Length > 10000)
+            {
+                throw new TwitterException(
+                    "Invalid message, the length of the message should be less than 10000 chars.");
+            }
+
+            var newDmEvent = new NewDirectMessageObject
+            {
+                Event = new Event
+                {
+                    EventType = "message_create",
+                    MessageCreate = new NewEvent_MessageCreate
+                    {
+                        MessageData = new NewEvent_MessageData {Text = activity.Text},
+                        target = new Target {recipient_id = activity.Recipient.Id}
+                    }
+                }
+            };
+
+            if (activity.SuggestedActions?.Actions != null && activity.SuggestedActions.Actions.Any())
+            {
+                newDmEvent.Event.MessageCreate.MessageData.QuickReply = new NewEvent_QuickReply
+                {
+                    Options = activity.SuggestedActions.Actions
+                        .Select(x => new NewEvent_QuickReplyOption {Label = x.Title}).ToList()
+                };
+            }
+
+            return newDmEvent;
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/ApplicationBuilderExtensions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/ApplicationBuilderExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Bot.Builder.Community.Adapters.Twitter.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Bot.Builder.Community.Adapters.Twitter
+{
+    public static class ApplicationBuilderExtensions
+    {
+        public static void UseTwitterAdapter(this IApplicationBuilder app)
+        {
+            var twitterOptions = app.ApplicationServices.GetRequiredService<IOptions<TwitterOptions>>().Value;
+            var uriPath = new Uri(twitterOptions.WebhookUri);
+
+            app.UseWhen(
+                context => context.Request.Path.StartsWithSegments(uriPath.AbsolutePath), 
+                builder => builder.UseMiddleware<WebhookMiddleware>());
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Bot.Builder.Community.Adapters.Twitter.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Bot.Builder.Community.Adapters.Twitter.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>Adapter for v4 of the Bot Builder .NET SDK to allow for a bot to be used with Twitter direct messages.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/</PackageProjectUrl>
+    <Authors>Tomislav Markovski</Authors>
+    <Company>Bot Builder Community</Company>
+    <Product />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.4.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Bot.Builder.Community.Adapters.Twitter.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Bot.Builder.Community.Adapters.Twitter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Adapter for v4 of the Bot Builder .NET SDK to allow for a bot to be used with Twitter direct messages.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <!-- <PackageLicenseExpression>MIT</PackageLicenseExpression> -->
     <PackageProjectUrl>https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/</PackageProjectUrl>
     <Authors>Tomislav Markovski</Authors>
     <Company>Bot Builder Community</Company>

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Hosting/WebhookHostingService.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Hosting/WebhookHostingService.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Hosting
+{        
+    /// <inheritdoc />
+    /// <summary>
+    /// Webhook Hosted Service
+    /// </summary>
+    public class WebhookHostedService : IHostedService
+    {
+        private readonly ILogger<WebhookHostedService> _logger;
+        private readonly TwitterOptions _options;
+        private readonly WebhooksPremiumManager _webhooksManager;
+        private readonly SubscriptionsManager _subscriptionsManager;
+
+        public WebhookHostedService(
+            IApplicationLifetime applicationLifetime,
+            IOptions<TwitterOptions> options,
+            ILogger<WebhookHostedService> logger)
+        {
+            _logger = logger;
+            _options = options.Value;
+            _webhooksManager = new WebhooksPremiumManager(_options);
+            _subscriptionsManager = new SubscriptionsManager(_options);
+
+            // Initialize logic after host has started, to ensure WebhookMiddleware
+            // is available for webhook registration
+            applicationLifetime.ApplicationStarted.Register(InitializeWebhookAsync);
+        }
+
+        private async void InitializeWebhookAsync()
+        {
+            if (_options.Tier != TwitterAccountApi.PremiumFree)
+            {
+                throw new NotSupportedException($"{_options.Tier} tier not yet supported");
+            }
+
+            var webhooks = await _webhooksManager.GetRegisteredWebhooks();
+            if (webhooks.Success)
+            {
+                if (webhooks.Data.Environments.FirstOrDefault(x => x.Name == _options.Environment) is EnvironmentRegistration environmentRegistration
+                    && environmentRegistration.Webhooks.FirstOrDefault() is WebhookRegistration webhookRegistration)
+                {
+                    if (webhookRegistration.RegisteredUrl == _options.WebhookUri)
+                    {
+                        if (webhookRegistration.IsValid)
+                        {
+                            // Webhook registered and valid.
+                            _logger.LogInformation("Found valid webhook {WebHook} for environment {Environment}", 
+                                _options.WebhookUri, _options.Environment);
+                        }
+                        else
+                        {
+                            _logger.LogWarning("Found invalid webhook {WebHook} for environment {Environment}. Attempting to update....", 
+                                _options.WebhookUri, _options.Environment);
+                            // Call update webhook to initiate CRC 
+                        }
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"Found webhook '{webhookRegistration.RegisteredUrl}', but configured uri is '{_options.WebhookUri}' " +
+                                         $"for environment '{_options.Environment}'. Attempting to update...");
+
+                        var removeResult = await _webhooksManager.UnregisterWebhook(webhookRegistration.Id, _options.Environment);
+
+                        if (!removeResult.Success)
+                        {
+                            _logger.LogError("Failed to remove old webhook.");
+                            return;
+                        }
+
+                        // Webhook Url is different than current one. Register new webhook.
+                        // This will override the webhook in PremiumFree tier, as only one webhook per environment is allowed
+                        var result = await _webhooksManager.RegisterWebhook(_options.WebhookUri, _options.Environment);
+                        if (result.Success)
+                        {
+                            _logger.LogInformation($"Webhook registration initiated");
+                        }
+                        else
+                        {
+                            _logger.LogError($"Webhook registration error: {string.Join(", ", result.Error.Errors.Select(x => x.Message))}");
+                        }
+                    }
+                }
+                else
+                {
+                    _logger.LogInformation($"Webhook not found. Registering [{_options.WebhookUri}] for [{_options.Environment}]");
+
+                    await _webhooksManager.RegisterWebhook(_options.WebhookUri, _options.Environment);
+                }
+
+                // Check subscription
+                var checkSubResult = await _subscriptionsManager.CheckSubscription(_options.Environment);
+                if (checkSubResult.Success)
+                {
+                    if (checkSubResult.Data)
+                    {
+                        _logger.LogInformation("Found valid subscription");
+                    }
+                    else
+                    {
+                        var subResult = await _subscriptionsManager.Subscribe(_options.Environment);
+                        if (subResult.Success)
+                        {
+                            _logger.LogInformation("Subscription registration completed");
+                        }
+                        else
+                        {
+                            _logger.LogError("Failed to register subscription: {Error}", 
+                                string.Join(", ", subResult.Error.Errors.Select(x => $"{x.Code}: {x.Message}")));
+                        }
+                    }
+                }
+                else
+                {
+                    _logger.LogError("Failed to check subscription: {Error}", 
+                        string.Join(", ", checkSubResult.Error.Errors.Select(x => $"{x.Code}: {x.Message}")));
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        /// <inheritdoc />
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Hosting/WebhookMiddleware.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Hosting/WebhookMiddleware.cs
@@ -1,0 +1,72 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using IMiddleware = Microsoft.AspNetCore.Http.IMiddleware;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Hosting
+{
+    public class WebhookMiddleware : IMiddleware
+    {
+        private readonly ILogger<WebhookMiddleware> _logger;
+        private readonly IBot _bot;
+        private readonly TwitterAdapter _adapter;
+        private readonly TwitterOptions _options;
+        private readonly WebhookInterceptor _interceptor;
+
+        public WebhookMiddleware(IOptions<TwitterOptions> options, ILogger<WebhookMiddleware> logger, IBot bot,
+            TwitterAdapter adapter)
+        {
+            _logger = logger;
+            _bot = bot;
+            _adapter = adapter;
+            _options = options.Value;
+            _interceptor = new WebhookInterceptor(_options.ConsumerSecret);
+        }
+
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            var result = await _interceptor.InterceptIncomingRequest(context.Request, OnDirectMessageReceived);
+            if (result.IsHandled)
+            {
+                context.Response.StatusCode = (int) HttpStatusCode.OK;
+                await context.Response.WriteAsync(result.Response);
+            }
+            else
+            {
+                _logger.LogError($"Failed to intercept message.");
+                await next(context);
+            }
+        }
+
+        private async void OnDirectMessageReceived(DirectMessageEvent obj)
+        {
+            _logger.LogInformation(
+                $"Direct Message from {obj.Sender.Name} (@{obj.Sender.ScreenName}): {obj.MessageText}");
+
+            // Important: Ignore messages originating from the bot else recursion happens
+            if (obj.Sender.ScreenName == _options.BotUsername) return;
+
+            if (_options.AllowedUsernamesConfigured()
+                && _options.AllowedUsernames.Contains(obj.Sender.ScreenName)
+                || !_options.AllowedUsernamesConfigured())
+            {
+                // Only respond if sender is different than the bot
+                await _bot.OnTurnAsync(new TurnContext(_adapter, new Activity
+                {
+                    Text = obj.MessageText,
+                    Type = "message",
+                    From = new ChannelAccount(obj.Sender.Id, obj.Sender.ScreenName),
+                    Recipient = new ChannelAccount(obj.Recipient.Id, obj.Recipient.ScreenName),
+                    Conversation = new ConversationAccount {Id = obj.Sender.Id}
+                }));
+            }
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/README.md
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/README.md
@@ -1,0 +1,76 @@
+# Twitter Adapter for Bot Framework SDK v4
+
+An adapter that integrates Twitter Direct Messages with the Bot Builder. The adapter sets up the required webhooks and responds to CRC requests.
+The webhooks code is based on the work by [Tweety](https://github.com/mmgrt/Tweety) with modifications to support the Premium tier of the Account Activity API.
+
+## Installation
+
+Use nuget to add the required dependencies
+
+    dotnet add package Bot.Builder.Community.Twitter.Adapter
+
+## Configuration
+
+Use the provided extensions to setup the adapter, middleware and hosted service in .NET Core
+
+Inside `ConfigureServices(IServiceCollection services)` in your Startup class add the adapter dependencies
+
+```cs
+services.AddTwitterAdapter(x => Configuration.Bind("TwitterOptions", x));
+```
+
+In your `void Configure(IApplicationBuilder app, IHostingEnvironment env)` method register the adapter middleware
+
+```cs
+app.UseTwitterAdapter();
+```
+
+In your `appsettings.json` add required configuration entries. See details below for explanation on each entry.
+
+```json
+  "TwitterOptions": {
+    "WebhookUri": "https://XXXXX.ngrok.io/twitter/adapter",
+    "AccessSecret": "",
+    "AccessToken": "",
+    "ConsumerKey": "",
+    "ConsumerSecret": "",
+    "Environment": "",
+    "Tier": "PremiumFree",
+    "BotUsername": "",
+    "AllowedUsernames": []
+  }
+```
+
+That's it.
+
+### Configuration notes
+
+#### WebhookUri
+
+This is public webhook uri that Twitter will integrate with. The adapter sets up a middleware that responds to the configred host in this Uri. The path portion of this address can be anything you like. Use Ngrok for development to test local callbacks.
+When deploying to the server, the configured hosted service will automatically update this webhook address if the twitter webhook and the configured webhook are different.
+Please note that if using the Free tier, you can only setup one webhook, so after you deploy to the server, running it locally will override the server webhook until you restart the web server.
+
+#### Access tokens and secrets
+
+Once you setup the Twitter developer account and create your app, you will find these at https://developer.twitter.com/en/apps/ under *Keys and tokens* in your app page
+
+#### Environment
+
+The name of the environment the bot will be configured to. Set this in your developer account at https://developer.twitter.com/en/account/environments under *Account Activity API*
+
+#### BotUsername
+
+This is the *App owner* configured in the above URL. This must be set to match the bot screen name - it used to detect and ignore messages that the bot sends to users. *If the username doesn't match, the bot will send it's response back to itself and get stuck in recursive calls.*
+
+#### AllowedUsernames
+
+This is just a convenience configuration that allows you to restrict the twitter screen names that the bot will respond to. If you want the bot to respond to everyone, leave this as is.
+
+### Supported features
+
+Currently, the adapter supports text and quick replies. More features coming soon. Contributions are welcome!
+
+### Future plans
+
+I'd like to integrate [Tweetinvi](https://github.com/linvi/tweetinvi) in place of the current `Webhooks` package as it is more feature complete, however due to a current [bug](https://github.com/linvi/tweetinvi/issues/849) in the library's WebhooksPlugin with namespace conflicts, this cannot be done until v5.0.

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/ServiceCollectionExtensions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/ServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Bot.Builder.Community.Adapters.Twitter.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Bot.Builder.Community.Adapters.Twitter
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddTwitterAdapter(this IServiceCollection collection, Action<TwitterOptions> contextDelegate)
+        {
+            collection.AddSingleton<IHostedService, WebhookHostedService>();
+            collection.AddSingleton<WebhookMiddleware>();
+            collection.AddSingleton<TwitterAdapter>();
+
+            collection.AddOptions();
+            collection.Configure(contextDelegate);
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterAdapter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Options;
+
+namespace Bot.Builder.Community.Adapters.Twitter
+{
+    public class TwitterAdapter : BotAdapter
+    {
+        private readonly DirectMessageSender _sender;
+
+        public TwitterAdapter(IOptions<TwitterOptions> options)
+        {
+            _sender = new DirectMessageSender(options.Value);
+        }
+
+        public override async Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext,
+            Activity[] activities, CancellationToken cancellationToken)
+        {
+            var responses = new List<ResourceResponse>();
+            foreach (var activity in activities)
+            {
+                await _sender.SendAsync(activity.AsTwitterMessage());
+                responses.Add(new ResourceResponse(activity.Id));
+            }
+
+            return responses.ToArray();
+        }
+
+        public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterOptions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterOptions.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+
+namespace Bot.Builder.Community.Adapters.Twitter
+{
+
+    /// <summary>
+    /// Required for any action, this represents the current user context.
+    /// </summary>
+    public class TwitterOptions
+    {
+        public string ConsumerKey { get; set; }
+        public string ConsumerSecret { get; set; }
+        public string AccessToken { get; set; }
+        public string AccessSecret { get; set; }
+        public string Environment { get; set; }
+        public TwitterAccountApi Tier { get; set; }
+        public string WebhookUri { get; set; }
+        public string BotUsername { get; set; }
+        public string[] AllowedUsernames { get; set; }
+
+        /// <summary>
+        /// Check if the current auth context is valid or not.
+        /// Null or Empty value for one on the auth properties will return false.
+        /// </summary>
+        public bool IsValid =>
+            !string.IsNullOrEmpty(ConsumerKey) &&
+            !string.IsNullOrEmpty(ConsumerSecret) &&
+            !string.IsNullOrEmpty(AccessToken) &&
+            !string.IsNullOrEmpty(AccessSecret) &&
+            !string.IsNullOrEmpty(WebhookUri) &&
+            (!string.IsNullOrEmpty(Environment) || Tier != TwitterAccountApi.PremiumFree);
+
+        public bool AllowedUsernamesConfigured() => AllowedUsernames != null && AllowedUsernames.Any();
+    }
+
+    public enum TwitterAccountApi
+    {
+        PremiumFree = 0,
+        PremiumPaid,
+        Enterprise
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Authentication/AuthHeaderBuilder.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Authentication/AuthHeaderBuilder.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Authentication
+{
+    /// <summary>
+    /// Twitter Authentication helper.
+    /// </summary>
+    public class AuthHeaderBuilder
+    {
+
+        /// <summary>
+        /// Returns a ready 'OAuth ..' prefixed header to set in any call to Twitter API.
+        /// </summary>
+        /// <param name="options">Twitter app auth context.</param>
+        /// <param name="method">The Request Http method.</param>
+        /// <param name="requestUrl">The Request uri along with any query parameter.</param>
+        /// <returns></returns>
+        public static string Build(TwitterOptions options, HttpMethod method, string requestUrl)
+        {
+
+            if (!Uri.TryCreate(requestUrl, UriKind.RelativeOrAbsolute, out var resourceUri))
+            {
+                throw new TwitterException("Invalid Resource Url format.");
+            }
+
+            if (options == null || !options.IsValid)
+            {
+                throw new TwitterException("Invalid Twitter options.");
+            }
+
+            const string oauthVersion = "1.0";
+            const string oauthSignatureMethod = "HMAC-SHA1";
+
+            // It could be any random string..
+            var oauthNonce = DateTime.Now.Ticks.ToString();
+
+            var epochTimeStamp =
+                (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
+
+            var oauthTimestamp = Convert.ToInt64(epochTimeStamp).ToString();
+
+            var signatureParams = new Dictionary<string, string>
+            {
+                {"oauth_consumer_key", options.ConsumerKey},
+                {"oauth_nonce", oauthNonce},
+                {"oauth_signature_method", oauthSignatureMethod},
+                {"oauth_timestamp", oauthTimestamp},
+                {"oauth_token", options.AccessToken},
+                {"oauth_version", oauthVersion}
+            };
+
+            var qParams = resourceUri.GetParams();
+            foreach (var qp in qParams)
+            {
+                signatureParams.Add(qp.Key, qp.Value);
+            }
+
+            var baseString = string.Join("&",
+                signatureParams.OrderBy(kpv => kpv.Key).Select(kpv => $"{kpv.Key}={kpv.Value}"));
+
+            var resourceUrl = requestUrl.Contains("?")
+                ? requestUrl.Substring(0, requestUrl.IndexOf("?", StringComparison.Ordinal))
+                : requestUrl;
+            baseString = string.Concat(method.Method.ToUpper(), "&", Uri.EscapeDataString(resourceUrl), "&",
+                Uri.EscapeDataString(baseString));
+
+            var oauthSignatureKey = string.Concat(Uri.EscapeDataString(options.ConsumerSecret), "&",
+                Uri.EscapeDataString(options.AccessSecret));
+
+            string oauthSignature;
+            using (var hasher = new HMACSHA1(Encoding.ASCII.GetBytes(oauthSignatureKey)))
+            {
+                oauthSignature = Convert.ToBase64String(hasher.ComputeHash(Encoding.ASCII.GetBytes(baseString)));
+            }
+
+            const string headerFormat = "OAuth oauth_nonce=\"{0}\", oauth_signature_method=\"{1}\", " +
+                                        "oauth_timestamp=\"{2}\", oauth_consumer_key=\"{3}\", " +
+                                        "oauth_token=\"{4}\", oauth_signature=\"{5}\", " +
+                                        "oauth_version=\"{6}\"";
+
+            return string.Format(headerFormat,
+                Uri.EscapeDataString(oauthNonce),
+                Uri.EscapeDataString(oauthSignatureMethod),
+                Uri.EscapeDataString(oauthTimestamp),
+                Uri.EscapeDataString(options.ConsumerKey),
+                Uri.EscapeDataString(options.AccessToken),
+                Uri.EscapeDataString(oauthSignature),
+                Uri.EscapeDataString(oauthVersion));
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Authentication/Extensions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Authentication/Extensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Authentication
+{
+    internal static class DictionaryExt
+    {
+        public static Dictionary<string, string> GetParams(this Uri uri)
+        {
+            try
+            {
+                var matches = Regex.Matches(uri.AbsoluteUri, @"[\?&](([^&=]+)=([^&=#]*))", RegexOptions.Compiled);
+                var keyValues = new Dictionary<string, string>(matches.Count);
+                foreach (Match m in matches)
+                {
+                    keyValues.Add(Uri.UnescapeDataString(m.Groups[2].Value), Uri.UnescapeDataString(m.Groups[3].Value));
+                }
+
+                return keyValues;
+            }
+            catch (Exception)
+            {
+                return new Dictionary<string, string>();
+            }
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/DirectMessageEvent.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/DirectMessageEvent.cs
@@ -1,0 +1,17 @@
+﻿using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models
+{
+    public class DirectMessageEvent : TwitterEvent
+    {
+
+        public TwitterUser Recipient { get; set; }
+        public TwitterUser Sender { get; set; }
+
+        public string MessageText { get; set; }
+        public TwitterEntities MessageEntities { get; set; }
+
+        public string JsonSource { get; set; }
+    }
+}
+

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/DirectMessageResult.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/DirectMessageResult.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models
+{
+
+    /// <summary>
+    /// The result of sending a new direct message.
+    /// </summary>
+    public class DirectMessageResult
+    {
+        /// <summary>
+        /// Created Timestamp.
+        /// </summary>
+        public DateTime Created { get; set; }
+
+
+        /// <summary>
+        /// Message Id.
+        /// </summary>
+        public string Id { get; set; }
+
+
+        /// <summary>
+        /// The Twitter User Id who the message was sent to.
+        /// </summary>
+        public string RecipientId { get; set; }
+
+
+        /// <summary>
+        /// The Twitter User Id who sent the message.
+        /// </summary>
+        public string SenderId { get; set; }
+
+
+        /// <summary>
+        /// The sent message Text.
+        /// </summary>
+        public string MessageText { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/InterceptionResult.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/InterceptionResult.cs
@@ -1,0 +1,55 @@
+﻿using System.Net;
+using System.Net.Http;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models
+{
+
+    /// <summary>
+    /// HttpRequestMessage Interception Result, See: <see cref="WebhookInterceptor"/>.
+    /// </summary>
+    public class InterceptionResult
+    {
+        /// <summary>
+        /// Determines of the request is handled internally, in this case, you should return <see cref="Response"/>.
+        /// </summary>
+        public bool IsHandled { get; internal set; }
+
+        /// <summary>
+        /// The <see cref="HttpResponseMessage"/> to return to the client if <see cref="IsHandled"/> is true.
+        /// If  <see cref="IsHandled"/> is false, this will be empty <see cref="HttpResponseMessage"/> with status code: <see cref="HttpStatusCode.OK"/>.
+        /// </summary>
+        public string Response { get; internal set; }
+
+        /// <summary>
+        /// The original request message, for reference purposes only.
+        /// </summary>
+        //public HttpRequestMessage RequestMessage { get; internal set; }
+
+        private InterceptionResult()
+        {
+
+        }
+
+        internal static InterceptionResult CreateHandled(string response)
+        {
+            return new InterceptionResult
+            {
+                IsHandled = true,
+                //RequestMessage = request,
+                Response = response
+            };
+        }
+
+        internal static InterceptionResult CreateUnhandled()
+        {
+            return new InterceptionResult
+            {
+                IsHandled = false,
+                //RequestMessage = request,
+                Response = string.Empty
+            };
+        }
+
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Result.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Result.cs
@@ -1,0 +1,36 @@
+﻿using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models
+{
+
+    /// <summary>
+    /// Wrapper to wrap any result for better errors understanding.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class Result<T>
+    {
+        public Result()
+        {
+            Success = false;
+        }
+        public Result(T data)
+        {
+            Data = data;
+            Success = true;
+        }
+
+        public Result(TwitterError err)
+        {
+            Error = err;
+            Success = false;
+
+        }
+
+        public T Data { get; private set; }
+
+        public TwitterError Error { get; private set; }
+
+        public bool Success { get; private set; }
+
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/CRCResponseToken.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/CRCResponseToken.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    internal class CRCResponseToken
+    {
+        [JsonProperty("response_token")]
+        public string Token { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/EnvironmentRegistration.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/EnvironmentRegistration.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    public class EnvironmentRegistration
+    {
+        [JsonProperty("environment_name")] public string Name { get; set; }
+
+        [JsonProperty("webhooks")] public IList<WebhookRegistration> Webhooks { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/HashtagEntity.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/HashtagEntity.cs
@@ -1,0 +1,10 @@
+﻿namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    public class HashtagEntity
+    {
+
+        public string text { get; set; }
+        public int[] indices { get; set; }
+
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/MediaEntity.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/MediaEntity.cs
@@ -1,0 +1,54 @@
+﻿namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+ 
+    public class MediaEntity
+    {
+        public long id { get; set; }
+        public string id_str { get; set; }
+        public int[] indices { get; set; }
+        public string media_url { get; set; }
+        public string media_url_https { get; set; }
+        public string url { get; set; }
+        public string display_url { get; set; }
+        public string expanded_url { get; set; }
+        public string type { get; set; }
+        public Sizes sizes { get; set; }
+    }
+
+    public class Sizes
+    {
+        public TwitterSizeMedium medium { get; set; }
+        public TwitterSizeThumb thumb { get; set; }
+        public TwitterSizeSmall small { get; set; }
+        public TwitterSizeLarge large { get; set; }
+    }
+
+    public class TwitterSizeMedium
+    {
+        public int w { get; set; }
+        public int h { get; set; }
+        public string resize { get; set; }
+    }
+
+    public class TwitterSizeThumb
+    {
+        public int w { get; set; }
+        public int h { get; set; }
+        public string resize { get; set; }
+    }
+
+    public class TwitterSizeSmall
+    {
+        public int w { get; set; }
+        public int h { get; set; }
+        public string resize { get; set; }
+    }
+
+    public class TwitterSizeLarge
+    {
+        public int w { get; set; }
+        public int h { get; set; }
+        public string resize { get; set; }
+    }
+
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/MessageCreate.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/MessageCreate.cs
@@ -1,0 +1,69 @@
+﻿namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+
+    public class MessageCreate
+    {
+        public long id { get; set; }
+        public string id_str { get; set; }
+        public string text { get; set; }
+        public TwitterFullUser sender { get; set; }
+        public int sender_id { get; set; }
+        public string sender_id_str { get; set; }
+        public string sender_screen_name { get; set; }
+        public TwitterFullUser recipient { get; set; }
+        public long recipient_id { get; set; }
+        public string recipient_id_str { get; set; }
+        public string recipient_screen_name { get; set; }
+        public string created_at { get; set; }
+        public TwitterEntities entities { get; set; }
+    }
+
+    public class TwitterFullUser
+    {
+        public long id { get; set; }
+        public string id_str { get; set; }
+        public string name { get; set; }
+        public string screen_name { get; set; }
+        public string location { get; set; }
+        public string description { get; set; }
+        public string url { get; set; }
+        public TwitterEntities entities { get; set; }
+        public bool _protected { get; set; }
+        public int followers_count { get; set; }
+        public int friends_count { get; set; }
+        public int listed_count { get; set; }
+        public string created_at { get; set; }
+        public int favourites_count { get; set; }
+        public string utc_offset { get; set; }
+        public string time_zone { get; set; }
+        public bool geo_enabled { get; set; }
+        public bool verified { get; set; }
+        public int statuses_count { get; set; }
+        public string lang { get; set; }
+        public bool contributors_enabled { get; set; }
+        public bool is_translator { get; set; }
+        public bool is_translation_enabled { get; set; }
+        public string profile_background_color { get; set; }
+        public string profile_background_image_url { get; set; }
+        public string profile_background_image_url_https { get; set; }
+        public bool profile_background_tile { get; set; }
+        public string profile_image_url { get; set; }
+        public string profile_image_url_https { get; set; }
+        public string profile_banner_url { get; set; }
+        public string profile_link_color { get; set; }
+        public string profile_sidebar_border_color { get; set; }
+        public string profile_sidebar_fill_color { get; set; }
+        public string profile_text_color { get; set; }
+        public bool profile_use_background_image { get; set; }
+        public bool has_extended_profile { get; set; }
+        public bool default_profile { get; set; }
+        public bool default_profile_image { get; set; }
+        public bool following { get; set; }
+        public bool follow_request_sent { get; set; }
+        public bool notifications { get; set; }
+        public string translator_type { get; set; }
+    }
+ 
+ 
+    
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/NewDirectMessageModels.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/NewDirectMessageModels.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+
+    public class NewDirectMessageObject
+    {
+        [JsonProperty("event")]
+        public Event Event { get; set; }
+    }
+      
+    public class Event
+    {
+        [JsonProperty("type")]
+        public string EventType { get; set; }
+
+        [JsonProperty("message_create")]
+        public NewEvent_MessageCreate MessageCreate { get; set; }
+    }
+
+    public class NewEvent_MessageCreate
+    {
+        public Target target { get; set; }
+
+        [JsonProperty("message_data")]
+        public NewEvent_MessageData MessageData { get; set; }
+    }
+ 
+    public class NewEvent_MessageData
+    {
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+        [JsonProperty("quick_reply")]
+        public NewEvent_QuickReply QuickReply { get; set; }
+    }
+
+    public class NewEvent_QuickReply
+    {
+        [JsonProperty("type")]
+        public string Type { get; } = "options";
+
+        [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
+        public IList<NewEvent_QuickReplyOption> Options { get; set; }
+    }
+
+    public class NewEvent_QuickReplyOption
+    {
+        [JsonProperty("label")]
+        public string Label { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/SymbolEntity.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/SymbolEntity.cs
@@ -1,0 +1,10 @@
+﻿namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    public class SymbolEntity
+    {
+
+        public string text { get; set; }
+        public int[] indices { get; set; }
+
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/TwitterEntities.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/TwitterEntities.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    public class TwitterEntities
+    {
+        public List<HashtagEntity> hashtags { get; set; }
+        public List<SymbolEntity> symbols { get; set; }
+        public List<UserMentionEntity> user_mentions { get; set; }
+        public List<UrlEntity> urls { get; set; }
+        public List<MediaEntity> media { get; set; }
+    }
+
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/TwitterError.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/TwitterError.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+
+    public class TwitterError
+    {
+        [JsonProperty("errors")]
+        public List<Error> Errors { get; set; }
+
+        public override string ToString()
+        {
+            return string.Join("\n", Errors.Select(err => $"Error Code: {err.Code}, Error Message: {err.Message}"));
+        }
+    }
+
+    public class Error
+    {
+
+        [JsonProperty("code")]
+        public int Code { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/TwitterUser.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/TwitterUser.cs
@@ -1,0 +1,50 @@
+﻿using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    public class TwitterUser
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("created_timestamp")]
+        public long CreatedTimestamp { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("screen_name")]
+        public string ScreenName { get; set; }
+
+        [JsonProperty("location")]
+        public string Location { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("_protected")]
+        public bool IsProtected { get; set; }
+
+        [JsonProperty("verified")]
+        public bool IsVerified { get; set; }
+
+        [JsonProperty("followers_count")]
+        public int FollowersCount { get; set; }
+
+        [JsonProperty("friends_count")]
+        public int FriendsCount { get; set; }
+
+        [JsonProperty("statuses_count")]
+        public int StatusesCount { get; set; }
+
+        [JsonProperty("profile_image_url")]
+        public string ProfileImage { get; set; }
+
+        [JsonProperty("profile_image_url_https")]
+        public string ProfileImageHttps { get; set; }
+    }
+
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/UrlEntity.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/UrlEntity.cs
@@ -1,0 +1,10 @@
+﻿namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    public class UrlEntity
+    {
+        public string url { get; set; }
+        public string expanded_url { get; set; }
+        public string display_url { get; set; }
+        public int[] indices { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/UserMentionEntity.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/UserMentionEntity.cs
@@ -1,0 +1,12 @@
+﻿namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    public class UserMentionEntity
+    {
+        public string screen_name { get; set; }
+        public string name { get; set; }
+        public long id { get; set; }
+        public string id_str { get; set; }
+        public int[] indices { get; set; }
+ 
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/WebhookDMResult.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/WebhookDMResult.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+
+    public class WebhookDMResult
+    {
+        [JsonProperty("direct_message_events")]
+        public List<DMEvent> Events { get; set; }
+
+        [JsonProperty("users")]
+        public Dictionary<string, TwitterUser> Users { get; set; }
+
+        public static implicit operator DirectMessageEvent(WebhookDMResult result)
+        {
+            var dmEvent = new DirectMessageEvent();
+
+            var tdmEvent = result.Events.First();
+
+            dmEvent.Id = tdmEvent.id;
+            dmEvent.Created = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(tdmEvent.created_timestamp);
+            dmEvent.Type = tdmEvent.type == "message_create" ? TwitterEventType.MessageCreate : TwitterEventType.Unknown;
+
+            dmEvent.MessageEntities = tdmEvent.message_create?.message_data?.entities;
+            if (tdmEvent.message_create.message_data.attachment != null)
+            {
+                dmEvent.MessageEntities.media = new List<MediaEntity>();
+                dmEvent.MessageEntities.media.Add(tdmEvent.message_create.message_data.attachment.media);
+            }
+           
+
+            dmEvent.MessageText = tdmEvent.message_create?.message_data?.text;
+            dmEvent.Recipient = result.Users.Where(u => u.Value.Id == tdmEvent.message_create.target.recipient_id)?.FirstOrDefault().Value;
+            dmEvent.Sender = result.Users.Where(u => u.Value.Id == tdmEvent.message_create.sender_id)?.FirstOrDefault().Value;
+
+            return dmEvent;
+        }
+    }
+
+    public class NewDmResult
+    {
+        public DMEvent @event { get; set; }
+    }
+
+    public class DMEvent
+    {
+        public string type { get; set; }
+        public string id { get; set; }
+        public long created_timestamp { get; set; }
+        public Message message_create { get; set; }
+
+        public static implicit operator DirectMessageResult(DMEvent dmevent)
+        {
+            var res = new DirectMessageResult();
+            res.Created = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(dmevent.created_timestamp);
+            res.Id = dmevent.id;
+            res.MessageText = dmevent.message_create.message_data.text;
+            res.RecipientId = dmevent.message_create.target.recipient_id;
+            res.SenderId = dmevent.message_create.sender_id;
+
+            return res;
+        }
+    }
+
+    public class Message
+    {
+        public Target target { get; set; }
+        public string sender_id { get; set; }
+        public Message_Data message_data { get; set; }
+    }
+
+    public class Target
+    {
+        public string recipient_id { get; set; }
+    }
+
+    public class Message_Data
+    {
+        public string text { get; set; }
+        public TwitterEntities entities { get; set; }
+        public Attachment attachment { get; set; }
+    }
+
+    public class Attachment
+    {
+        public string type { get; set; }
+        public MediaEntity media { get; set; }
+
+    }
+
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/WebhookRegistration.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/WebhookRegistration.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    public class WebhookRegistration
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+
+        [JsonProperty("url")] public string RegisteredUrl { get; set; }
+
+        [JsonProperty("valid")] public bool IsValid { get; set; }
+
+        [JsonProperty("created_timestamp ")] public long CreatedTimestamp { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/WebhookResult.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter/WebhookResult.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter
+{
+    public class WebhookResult
+    {
+        [JsonProperty("environments")] public IList<EnvironmentRegistration> Environments { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/TwitterEvent.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/TwitterEvent.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models
+{
+    public class TwitterEvent
+    {
+        public string Id { get; internal set; }
+        public TwitterEventType Type { get; internal set; }
+        public DateTime Created { get; internal set; }
+
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/TwitterEventType.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/TwitterEventType.cs
@@ -1,0 +1,8 @@
+﻿namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models
+{
+    public enum TwitterEventType
+    {
+        MessageCreate,
+        Unknown
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/TwitterException.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/TwitterException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models
+{
+    /// <summary>
+    /// Exception thrown by Twitter.
+    /// </summary>
+    public class TwitterException : Exception
+    {
+        internal TwitterException(string message) : base(message)
+        {
+
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/DirectMessageSender.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/DirectMessageSender.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Authentication;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Services
+{
+
+    /// <summary>
+    /// Helper class to send Direct Message to twitter user using the screen name.
+    /// </summary>
+    public class DirectMessageSender
+    {
+        public TwitterOptions Options { get; set; }
+
+        public DirectMessageSender(TwitterOptions context)
+        {
+            Options = context;
+        }
+
+
+        /// <summary>
+        /// Send a direct message to User from the current user (using Options).
+        /// </summary>
+        /// <param name="toScreenName">To (screen name without '@' sign)</param>
+        /// <param name="messageText">Message Text to send.. Less than 140 char.</param>
+        /// <returns>
+        /// </returns>
+        [Obsolete("Use SendAsync instead.")]
+        public async Task<Result<MessageCreate>> Send(string toScreenName, string messageText)
+        {
+
+            //TODO: Provide a generic class to make Twitter API Requests.
+
+            if (string.IsNullOrEmpty(messageText))
+            {
+                throw new TwitterException("You can't send an empty message.");
+            }
+
+            if (messageText.Length > 140)
+            {
+                throw new TwitterException(
+                    "You can't send more than 140 char using this end point, use SendAsync instead.");
+            }
+
+            messageText = Uri.EscapeDataString(messageText);
+            var resourceUrl =
+                $"https://api.twitter.com/1.1/direct_messages/new.json?Text={messageText}&screen_name={toScreenName}";
+
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+
+                client.DefaultRequestHeaders.Add("Authorization",
+                    AuthHeaderBuilder.Build(Options, HttpMethod.Post, resourceUrl));
+
+                response = await client.PostAsync(resourceUrl, new StringContent(""));
+            }
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+
+                var msgCreateJson = await response.Content.ReadAsStringAsync();
+                var mCreateObj = JsonConvert.DeserializeObject<MessageCreate>(msgCreateJson);
+                return new Result<MessageCreate>(mCreateObj);
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                return new Result<MessageCreate>(err);
+            }
+
+            return new Result<MessageCreate>();
+        }
+
+
+        /// <summary>
+        /// Send a direct message to a user by userId, from the current user (using Options).
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Result<DirectMessageResult>> SendAsync(NewDirectMessageObject message)
+        {
+            var resourceUrl = $"https://api.twitter.com/1.1/direct_messages/events/new.json";
+            
+            var jsonObj = JsonConvert.SerializeObject(message);
+            
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Add("Authorization",
+                    AuthHeaderBuilder.Build(Options, HttpMethod.Post, resourceUrl));
+                
+                response = await client.PostAsync(resourceUrl,
+                    new StringContent(jsonObj, Encoding.UTF8, "application/json"));
+            }
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var msgCreateJson = await response.Content.ReadAsStringAsync();
+                var mCreateObj = JsonConvert.DeserializeObject<NewDmResult>(msgCreateJson);
+                return new Result<DirectMessageResult>(mCreateObj.@event);
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                return new Result<DirectMessageResult>(err);
+            }
+            return new Result<DirectMessageResult>();
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/SubscriptionsManager.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/SubscriptionsManager.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Authentication;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Services
+{
+
+    /// <summary>
+    /// This class will help in managing the webhook subscription.
+    /// </summary>
+    public class SubscriptionsManager
+    {
+        public TwitterOptions Options { get; set; }
+
+        public SubscriptionsManager(TwitterOptions context)
+        {
+            Options = context;
+        }
+
+
+        /// <summary>
+        /// Subscribe current user (from the auth context) to a webhook by Id.
+        /// </summary>
+        /// <param name="environmentName">The name of the environment to subscribe to.</param>
+        /// <returns>true indicates successful subscription.</returns>
+        public async Task<Result<bool>> Subscribe(string environmentName)
+        {
+
+            if (string.IsNullOrEmpty(environmentName))
+            {
+                throw new ArgumentException(nameof(environmentName));
+            }
+            var resourceUrl = $"https://api.twitter.com/1.1/account_activity/all/{environmentName}/subscriptions.json";
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Add("Authorization", AuthHeaderBuilder.Build(Options, HttpMethod.Post, resourceUrl));
+
+                response = await client.PostAsync(resourceUrl, new StringContent("")).ConfigureAwait(false);
+            }
+
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                return new Result<bool>(true);
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                return new Result<bool>(err);
+            }
+            return new Result<bool>();
+
+        }
+
+        /// <summary>
+        /// Checks if the current user (from the auth context) is subscribed to a webhook by Id.
+        /// </summary>
+        /// <param name="environmentName"></param>
+        /// <returns>true indicates existed subscription.</returns>
+        public async Task<Result<bool>> CheckSubscription(string environmentName)
+        {
+
+            if (string.IsNullOrEmpty(environmentName))
+            {
+                throw new ArgumentException(nameof(environmentName));
+            }
+            
+            var resourceUrl = $"https://api.twitter.com/1.1/account_activity/all/{environmentName}/subscriptions.json";
+
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+
+                client.DefaultRequestHeaders.Add("Authorization", AuthHeaderBuilder.Build(Options, HttpMethod.Get, resourceUrl));
+
+                response = await client.GetAsync(resourceUrl).ConfigureAwait(false);
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                return new Result<bool>(true);
+            }
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                if(err.Errors.Count == 1 && err.Errors[0].Code == 34)
+                {
+                    // Twitter API will return : {"code":34,"message":"Sorry, that page does not exist."} if you try to check a webhook with 0 subscribers,
+                    // Which means, you're not subscribed.
+                    return new Result<bool>(false);
+                }
+
+                return new Result<bool>(err);
+            }
+            else
+            {
+
+                //TODO: Provide a way to return httpstatus code 
+                return new Result<bool>();
+            }
+
+
+        }
+
+
+        /// <summary>
+        /// Unsubscribe current user (from the auth context) from a webhook by Id.
+        /// </summary>
+        /// <param name="webhookId">Webhook Id to unsubscribe from.</param>
+        /// <returns>true indicates successful deletion.</returns>
+        public async Task<Result<bool>> Unsubscribe(string webhookId)
+        {
+
+            if (string.IsNullOrEmpty(webhookId))
+            {
+                throw new ArgumentException(nameof(webhookId));
+            }
+
+            //TODO: Provide a generic class to make Twitter API Requests.
+            var resourceUrl = $"https://api.twitter.com/1.1/account_activity/webhooks/{webhookId}/subscriptions.json";
+
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+
+                client.DefaultRequestHeaders.Add("Authorization", AuthHeaderBuilder.Build(Options, HttpMethod.Delete, resourceUrl));
+
+                response = await client.DeleteAsync(resourceUrl).ConfigureAwait(false);
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                return new Result<bool>(true);
+            }
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                if (err.Errors.Count == 1 && err.Errors[0].Code == 34)
+                {
+                    // Twitter API will return : {"code":34,"message":"Sorry, that page does not exist."} if you try to check a webhook with 0 subscribers,
+                    // Which means, you're not subscribed.
+                    return new Result<bool>(true);
+                }
+
+                return new Result<bool>(err);
+            }
+            else
+            {
+
+                //TODO: Provide a way to return httpstatus code 
+                return new Result<bool>();
+            }
+
+
+        }
+
+
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/WebhookInterceptor.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/WebhookInterceptor.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Services
+{
+    /// <summary>
+    /// This class is responsible to intercept incoming requests to the server
+    /// and handle them properly.
+    /// </summary>
+    public class WebhookInterceptor
+    {
+
+        /// <summary>
+        /// Twitter App Consumer Secret.
+        /// Used to Hash incoming/ outgoing data.
+        /// </summary>
+        public string ConsumerSecret { get; set; }
+
+
+        /// <summary>
+        /// Create a new instance of <see cref="WebhookInterceptor"/> with your Twitter App Consumer Key.
+        /// 
+        /// </summary>
+        /// <param name="consumerSecret">Twitter App Consumer Key, used for hashing.</param>
+        public WebhookInterceptor(string consumerSecret)
+        {
+            ConsumerSecret = consumerSecret;
+        }
+
+
+        /// <summary>
+        /// Intercept incoming requests to the server to handle them according to Twitter Documentation, Currently:
+        ///     - Challenge Response Check.
+        ///     - Incoming DirectMessage.
+        /// </summary>
+        /// <param name="requestMessage">Thr request message object you received.</param>
+        /// <param name="OnDirectMessageRecieved">If this is an incoming direct message, this callback will be fired along with the message object <see cref="DirectMessageEvent"/>.</param>
+        /// <returns>
+        /// <see cref="InterceptionResult"/> Interception result.
+        /// </returns>
+        public async Task<InterceptionResult> InterceptIncomingRequest(HttpRequest requestMessage, Action<DirectMessageEvent> OnDirectMessageRecieved)
+        {
+            if (string.IsNullOrEmpty(ConsumerSecret))
+            {
+                throw new TwitterException("Consumer Secret can't be null.");
+            }
+
+            if (HttpMethods.IsGet(requestMessage.Method))
+            {
+                if (!requestMessage.Query.TryGetValue("crc_token", out var values))
+                    return InterceptionResult.CreateUnhandled();
+
+                // Challenge Response Check Request:
+                var crcToken = values.First();
+                var response = AcceptChallenge(crcToken);
+                return InterceptionResult.CreateHandled(response);
+            }
+            else if (HttpMethods.IsPost(requestMessage.Method))
+            {
+                if (!requestMessage.Headers.TryGetValue("x-twitter-webhooks-signature", out var header))
+                {
+                    return InterceptionResult.CreateUnhandled();
+                }
+
+                var payloadSignature = header.First();
+                var streamReader = new StreamReader(requestMessage.Body);
+                var payload = await streamReader.ReadToEndAsync();
+
+
+                var signatureMatch = IsValidTwitterPostRequest(payloadSignature, payload);
+                if (!signatureMatch)
+                {
+                    //This is intersecting, a twitter signature key 'x-twitter-webhooks-signature' is there but it's wrong..!
+                    //return InterceptionResult.CreateHandled(new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest), requestMessage);
+                    throw new TwitterException("Invalid signature");
+                }
+
+                try
+                {
+                    var dmResult = JsonConvert.DeserializeObject<WebhookDMResult>(payload);
+                    DirectMessageEvent eventResult = dmResult;
+                    eventResult.JsonSource = payload;
+
+                    OnDirectMessageRecieved?.Invoke(eventResult);
+                    return InterceptionResult.CreateHandled(string.Empty);
+                }
+                catch 
+                {
+                    return InterceptionResult.CreateHandled(string.Empty);
+                    //Failed to deserialize twitter direct message,
+                    //TODO: Handle in a better way.. perhaps send the json?
+                }
+            }
+            return InterceptionResult.CreateUnhandled();
+        }
+        
+        private string AcceptChallenge(string crcToken)
+        {
+            var hashKeyArray = Encoding.UTF8.GetBytes(ConsumerSecret);
+            var crcTokenArray = Encoding.UTF8.GetBytes(crcToken);
+
+            var hmacSha256Alg = new HMACSHA256(hashKeyArray);
+
+            var computedHash = hmacSha256Alg.ComputeHash(crcTokenArray);
+
+            var challengeToken = $"sha256={Convert.ToBase64String(computedHash)}";
+
+            var responseToken = new CRCResponseToken
+            {
+                Token = challengeToken
+            };
+
+            var jsonResponse = JsonConvert.SerializeObject(responseToken);
+
+            return jsonResponse;
+        }
+
+        private bool IsValidTwitterPostRequest(string twWebhookSignature, string payload)
+        {
+            var hashKeyArray = Encoding.UTF8.GetBytes(ConsumerSecret);
+            var hmacSha256Alg = new HMACSHA256(hashKeyArray);
+
+            var computedHash = hmacSha256Alg.ComputeHash(Encoding.UTF8.GetBytes(payload));
+            var localHashedSignature = $"sha256={Convert.ToBase64String(computedHash)}";
+
+            return localHashedSignature == twWebhookSignature;
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/WebhooksEnterpriseManager.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/WebhooksEnterpriseManager.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Authentication;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Services
+{
+
+    /// <summary>
+    /// This class will help in managing the webhooks registrations.
+    /// </summary>
+    public class WebhooksEnterpriseManager
+    {
+
+        public TwitterOptions Options { get; set; }
+
+        public WebhooksEnterpriseManager(TwitterOptions context)
+        {
+            Options = context;
+        }
+
+
+        /// <summary>
+        /// Retrieve a list of <see cref="WebhookRegistration"/> associated with the user (from the auth context).
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Result<List<WebhookRegistration>>> GetRegisteredWebhooks()
+        {
+            //string resourceUrl = $"https://api.twitter.com/1.1/account_activity/webhooks.json";
+            var resourceUrl = $"https://api.twitter.com/1.1/account_activity/all/webhooks.json";
+
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+
+                client.DefaultRequestHeaders.Add("Authorization", AuthHeaderBuilder.Build(Options, HttpMethod.Get, resourceUrl));
+
+                response = await client.GetAsync(resourceUrl);
+            }
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var subs = JsonConvert.DeserializeObject<List<WebhookRegistration>>(jsonResponse);
+                return new Result<List<WebhookRegistration>>(subs);
+            }
+
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                return new Result<List<WebhookRegistration>>(err);
+            }
+            else
+            {
+                return new Result<List<WebhookRegistration>>();
+            }
+
+        }
+
+        /// <summary>
+        /// Register a new webhook url using the current user (from the auth context).
+        /// </summary>
+        /// <param name="url">The webhook url to register.</param>
+        /// <returns></returns>
+        public async Task<Result<WebhookRegistration>> RegisterWebhook(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentException(nameof(url));
+            }
+
+            //TODO: Provide a generic class to make Twitter API Requests.
+            var urlParam = Uri.EscapeUriString(url);
+            var resourceUrl = $"https://api.twitter.com/1.1/account_activity/webhooks.json?url={urlParam}";
+
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+
+                client.DefaultRequestHeaders.Add("Authorization", AuthHeaderBuilder.Build(Options, HttpMethod.Post, resourceUrl));
+
+                response = await client.PostAsync(resourceUrl, new StringContent(""));
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var sub = JsonConvert.DeserializeObject<WebhookRegistration>(jsonResponse);
+                return new Result<WebhookRegistration>(sub);
+            }
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                return new Result<WebhookRegistration>(err);
+            }
+            else
+            {
+                //TODO: Provide a way to return httpstatus code 
+
+                return new Result<WebhookRegistration>();
+            }
+
+        }
+
+
+        /// <summary>
+        /// Unregister a webhook from current user (from the auth context) by Id.
+        /// </summary>
+        /// <param name="webhookId">The Webhook Id to unregister.</param>
+        /// <returns></returns>
+        public async Task<Result<bool>> UnregisterWebhook(string webhookId)
+        {
+
+            //TODO: Provide a generic class to make Twitter API Requests.
+
+            var resourceUrl = $"https://api.twitter.com/1.1/account_activity/webhooks/{webhookId}.json";
+
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+
+                client.DefaultRequestHeaders.Add("Authorization", AuthHeaderBuilder.Build(Options, HttpMethod.Delete, resourceUrl));
+
+                response = await client.DeleteAsync(resourceUrl);
+            }
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                return new Result<bool>(true);
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                return new Result<bool>(err);
+            }
+            else
+            {
+                //TODO: Provide a way to return httpstatus code 
+
+                return new Result<bool>();
+            }
+
+        }
+
+
+
+    }
+}

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/WebhooksPremiumManager.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/WebhooksPremiumManager.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Authentication;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Services
+{
+
+    /// <summary>
+    /// This class will help in managing the webhooks registrations.
+    /// </summary>
+    public class WebhooksPremiumManager
+    {
+        /// <summary>
+        /// Gets or sets the auth context.
+        /// </summary>
+        /// <value>The auth context.</value>
+        public TwitterOptions Options { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Bot.Builder.Community.Adapters.Twitter.Webhooks.Services.WebhooksPremiumManager"/> class.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        public WebhooksPremiumManager(TwitterOptions context)
+        {
+            Options = context;
+        }
+
+
+        /// <summary>
+        /// Retrieve a list of <see cref="WebhookRegistration"/> associated with the user (from the auth context).
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Result<WebhookResult>> GetRegisteredWebhooks()
+        {
+            var resourceUrl = $"https://api.twitter.com/1.1/account_activity/all/webhooks.json";
+
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+
+                client.DefaultRequestHeaders.Add("Authorization", AuthHeaderBuilder.Build(Options, HttpMethod.Get, resourceUrl));
+
+                response = await client.GetAsync(resourceUrl).ConfigureAwait(false);
+            }
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var subs = JsonConvert.DeserializeObject<WebhookResult>(jsonResponse);
+                return new Result<WebhookResult>(subs);
+            }
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                return new Result<WebhookResult>(err);
+            }
+            return new Result<WebhookResult>();
+        }
+
+        /// <summary>
+        /// Register a new webhook url using the current user (from the auth context).
+        /// </summary>
+        /// <param name="url">The webhook url to register.</param>
+        /// <param name="environmentName">Environment name</param>
+        /// <returns></returns>
+        public async Task<Result<WebhookRegistration>> RegisterWebhook(string url, string environmentName)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentException(nameof(url));
+            }
+
+            //TODO: Provide a generic class to make Twitter API Requests.
+            var urlParam = Uri.EscapeUriString(url);
+            var resourceUrl = $"https://api.twitter.com/1.1/account_activity/all/{environmentName}/webhooks.json?url={urlParam}";
+
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+
+                client.DefaultRequestHeaders.Add("Authorization", AuthHeaderBuilder.Build(Options, HttpMethod.Post, resourceUrl));
+
+                response = await client.PostAsync(resourceUrl, new StringContent("")).ConfigureAwait(false);
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var sub = JsonConvert.DeserializeObject<WebhookRegistration>(jsonResponse);
+                return new Result<WebhookRegistration>(sub);
+            }
+
+            if (!string.IsNullOrEmpty(jsonResponse))
+            {
+                var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+                return new Result<WebhookRegistration>(err);
+            }
+
+            return new Result<WebhookRegistration>();
+
+        }
+
+
+        /// <summary>
+        /// Unregister a webhook from current user (from the auth context) by Id.
+        /// </summary>
+        /// <param name="webhookId">The Webhook Id to unregister.</param>
+        /// <returns></returns>
+        public async Task<Result<bool>> UnregisterWebhook(string webhookId, string environmentName)
+        {
+
+            //TODO: Provide a generic class to make Twitter API Requests.
+
+            var resourceUrl = $"https://api.twitter.com/1.1/account_activity/all/{environmentName}/webhooks/{webhookId}.json";
+
+            HttpResponseMessage response;
+            using (var client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Add("Authorization", AuthHeaderBuilder.Build(Options, HttpMethod.Delete, resourceUrl));
+                response = await client.DeleteAsync(resourceUrl).ConfigureAwait(false);
+            }
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                return new Result<bool>(true);
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrEmpty(jsonResponse))
+            {
+                return new Result<bool>();
+            }
+
+            var err = JsonConvert.DeserializeObject<TwitterError>(jsonResponse);
+            return new Result<bool>(err);
+
+        }
+    }
+}

--- a/samples/Twitter Adapter Sample/BotConfiguration.bot
+++ b/samples/Twitter Adapter Sample/BotConfiguration.bot
@@ -1,0 +1,15 @@
+﻿{
+  "name": "Twitter_Adapter_Sample",
+  "services": [
+    {
+      "type": "endpoint",
+      "name": "development",
+      "endpoint": "http://localhost:3978/api/messages",
+      "appId": "",
+      "appPassword": "",
+      "id": "1"
+    }
+  ],
+  "padlock": "",
+  "version": "2.0"
+}

--- a/samples/Twitter Adapter Sample/Program.cs
+++ b/samples/Twitter Adapter Sample/Program.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace TwitterAdapter_Sample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .ConfigureLogging((hostingContext, logging) =>
+                {
+                    // Add Azure Logging
+                    logging.AddAzureWebAppDiagnostics();
+
+                    // Logging Options.
+                    // There are other logging options available:
+                    // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-2.1
+                    // logging.AddDebug();
+                    // logging.AddConsole();
+                })
+
+                // Logging Options.
+                // Consider using Application Insights for your logging and metrics needs.
+                // https://azure.microsoft.com/en-us/services/application-insights/
+                // .UseApplicationInsights()
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/samples/Twitter Adapter Sample/README.md
+++ b/samples/Twitter Adapter Sample/README.md
@@ -1,0 +1,69 @@
+﻿# EchoBot
+
+Bot Framework v4 echo bot sample.
+
+This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to create a simple bot that accepts input from the user and echoes it back.
+
+## Prerequisites
+
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 2.1
+
+  ```bash
+  # determine dotnet version
+  dotnet --version
+  ```
+
+## To try this sample
+
+- In a terminal, navigate to `EchoBot`
+
+    ```bash
+    # change into project folder
+    cd # EchoBot
+    ```
+
+- Run the bot from a terminal or from Visual Studio, choose option A or B.
+
+  A) From a terminal
+
+  ```bash
+  # run the bot
+  dotnet run
+  ```
+
+  B) Or from Visual Studio
+
+  - Launch Visual Studio
+  - File -> Open -> Project/Solution
+  - Navigate to `EchoBot` folder
+  - Select `EchoBot.csproj` file
+  - Press `F5` to run the project
+
+## Testing the bot using Bot Framework Emulator
+
+[Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator version 4.3.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to the bot using Bot Framework Emulator
+
+- Launch Bot Framework Emulator
+- File -> Open Bot
+- Enter a Bot URL of `http://localhost:3978/api/messages`
+
+## Deploy the bot to Azure
+
+To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
+
+## Further reading
+
+- [Bot Framework Documentation](https://docs.botframework.com)
+- [Bot Basics](https://docs.microsoft.com/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
+- [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
+- [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+- [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+- [Azure Portal](https://portal.azure.com)
+- [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)
+- [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)

--- a/samples/Twitter Adapter Sample/Startup.cs
+++ b/samples/Twitter Adapter Sample/Startup.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
+
+namespace TwitterAdapter_Sample
+{
+    using System;
+    using System.Linq;
+    using Bot.Builder.Community.Twitter.Adapter;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Builder.Integration.AspNet.Core;
+    using Microsoft.Bot.Configuration;
+    using Microsoft.Bot.Connector.Authentication;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+
+    public class Startup
+    {
+        private ILoggerFactory _loggerFactory;
+        private bool _isProduction = false;
+
+        public Startup(IHostingEnvironment env)
+        {
+            _isProduction = env.IsProduction();
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Configuration = builder.Build();
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTwitterAdapter(x => Configuration.Bind("TwitterOptions", x));
+
+            services.AddBot<TwitterAdapterSampleBot>(options =>
+            {
+                var secretKey = Configuration.GetSection("botFileSecret")?.Value;
+                var botFilePath = Configuration.GetSection("botFilePath")?.Value;
+
+                var botConfig = BotConfiguration.Load(botFilePath ?? @".\BotConfiguration.bot", secretKey);
+                services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot config file could not be loaded. ({botConfig})"));
+
+                var environment = _isProduction ? "production" : "development";
+                var service = botConfig.Services.FirstOrDefault(s => s.Type == "endpoint" && s.Name == environment);
+                if (!(service is EndpointService endpointService))
+                {
+                    throw new InvalidOperationException($"The .bot file does not contain an endpoint with name '{environment}'.");
+                }
+
+                options.CredentialProvider = new SimpleCredentialProvider(endpointService.AppId, endpointService.AppPassword);
+
+                ILogger logger = _loggerFactory.CreateLogger<TwitterAdapterSampleBot>();
+
+                options.OnTurnError = async (context, exception) =>
+                {
+                    logger.LogError($"Exception caught : {exception}");
+                    await context.SendActivityAsync("Sorry, it looks like something went wrong.");
+                };
+            });
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+
+            app.UseDefaultFiles()
+                .UseStaticFiles()
+                .UseBotFramework()
+                .UseTwitterAdapter();
+        }
+    }
+}

--- a/samples/Twitter Adapter Sample/Twitter Adapter Sample.csproj
+++ b/samples/Twitter Adapter Sample/Twitter Adapter Sample.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="BotConfiguration.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bot.Builder.Community.Twitter.Adapter" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.4.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.2.5" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Twitter Adapter Sample/TwitterAdapterSampleBot.cs
+++ b/samples/Twitter Adapter Sample/TwitterAdapterSampleBot.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+
+namespace TwitterAdapter_Sample
+{
+    public class TwitterAdapterSampleBot : IBot
+    {
+        public async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            switch (turnContext.Activity.Type)
+            {
+                case ActivityTypes.Message:
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"Echo: {turnContext.Activity.Text}"), cancellationToken);
+                    break;
+            }
+        }
+    }
+}

--- a/samples/Twitter Adapter Sample/appsettings.json
+++ b/samples/Twitter Adapter Sample/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+  "TwitterOptions": {
+    "WebhookUri": "",
+    "AccessSecret": "",
+    "AccessToken": "",
+    "ConsumerKey": "",
+    "ConsumerSecret": "",
+    "Environment": "",
+    "Tier": "PremiumFree", // Available values [ "PremiumFree", "PremiumPaid", "Enterprise" ]
+    "BotUsername": "", // Configure your bot twitter screen name. This is used to detect messages originating from the bot to prevent recursion
+    "AllowedUsernames": [] // If configured, the bot will only respond to these usernames. Leave empty to respond to everyone
+  }
+}

--- a/samples/Twitter Adapter Sample/wwwroot/default.htm
+++ b/samples/Twitter Adapter Sample/wwwroot/default.htm
@@ -1,0 +1,420 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>EchoBot</title>
+    <style>
+        body {
+            margin: 0px;
+            padding: 0px;
+            font-family: Segoe UI;
+        }
+
+        html,
+        body {
+            height: 100%;
+        }
+
+        header {
+            background-image: url("data:image/svg+xml,%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 4638.9 651.6' style='enable-background:new 0 0 4638.9 651.6;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bfill:%2355A0E0;%7D .st1%7Bfill:none;%7D .st2%7Bfill:%230058A8;%7D .st3%7Bfill:%23328BD8;%7D .st4%7Bfill:%23B6DCF1;%7D .st5%7Bopacity:0.2;fill:url(%23SVGID_1_);enable-background:new ;%7D%0A%3C/style%3E%3Crect y='1.1' class='st0' width='4640' height='646.3'/%3E%3Cpath class='st1' d='M3987.8,323.6L4310.3,1.1h-65.6l-460.1,460.1c-17.5,17.5-46.1,17.5-63.6,0L3260.9,1.1H0v646.3h3660.3 L3889,418.7c17.5-17.5,46.1-17.5,63.6,0l228.7,228.7h66.6l-260.2-260.2C3970.3,369.8,3970.3,341.1,3987.8,323.6z'/%3E%3Cpath class='st2' d='M3784.6,461.2L4244.7,1.1h-983.9l460.1,460.1C3738.4,478.7,3767.1,478.7,3784.6,461.2z'/%3E%3Cpath class='st3' d='M4640,1.1h-329.8l-322.5,322.5c-17.5,17.5-17.5,46.1,0,63.6l260.2,260.2H4640L4640,1.1L4640,1.1z'/%3E%3Cpath class='st4' d='M3889,418.8l-228.7,228.7h521.1l-228.7-228.7C3935.2,401.3,3906.5,401.3,3889,418.8z'/%3E%3ClinearGradient id='SVGID_1_' gradientUnits='userSpaceOnUse' x1='3713.7576' y1='438.1175' x2='3911.4084' y2='14.2535' gradientTransform='matrix(1 0 0 -1 0 641.3969)'%3E%3Cstop offset='0' style='stop-color:%23FFFFFF;stop-opacity:0.5'/%3E%3Cstop offset='1' style='stop-color:%23FFFFFF'/%3E%3C/linearGradient%3E%3Cpath class='st5' d='M3952.7,124.5c-17.5-17.5-46.1-17.5-63.6,0l-523,523h1109.6L3952.7,124.5z'/%3E%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            background-size: 100%;
+            background-position: right;
+            background-color: #55A0E0;
+            width: 100%;
+            font-size: 44px;
+            height: 120px;
+            color: white;
+            padding: 30px 0 40px 0px;
+            display: inline-block;
+        }
+
+        .header-icon {
+            background-image: url("data:image/svg+xml;utf8,%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20150.2%20125%22%20style%3D%22enable-background%3Anew%200%200%20150.2%20125%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23FFFFFF%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.5%22%20class%3D%22st0%22%20width%3D%22149.7%22%20height%3D%22125%22/%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M59%2C102.9L21.8%2C66c-3.5-3.5-3.5-9.1%2C0-12.5l37-36.5l2.9%2C3l-37%2C36.4c-1.8%2C1.8-1.8%2C4.7%2C0%2C6.6l37.2%2C37L59%2C102.9z%22%0A%09%09/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M92.5%2C102.9l-3-3l37.2-37c0.9-0.9%2C1.4-2%2C1.4-3.3c0-1.2-0.5-2.4-1.4-3.3L89.5%2C20l2.9-3l37.2%2C36.4%0A%09%09c1.7%2C1.7%2C2.6%2C3.9%2C2.6%2C6.3s-0.9%2C4.6-2.6%2C6.3L92.5%2C102.9z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M90.1%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C98.1%2C64.7%2C94.4%2C68.4%2C90.1%2C68.4z%0A%09%09%20M90.1%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S91.9%2C56.5%2C90.1%2C56.5z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M61.4%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C69.5%2C64.7%2C65.8%2C68.4%2C61.4%2C68.4z%0A%09%09%20M61.4%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S63.3%2C56.5%2C61.4%2C56.5z%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            float: left;
+            height: 140px;
+            width: 140px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-text {
+            padding-left: 1%;
+            color: #FFFFFF;
+            font-family: "Segoe UI";
+            font-size: 72px;
+            font-weight: 300;
+            letter-spacing: 0.35px;
+            line-height: 96px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-inner-container {
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+            vertical-align: middle;
+        }
+
+        .header-inner-container::after {
+            content: "";
+            clear: both;
+            display: table;
+        }
+
+        .main-content-area {
+            padding-left: 30px;
+        }
+
+        .content-title {
+            color: #000000;
+            font-family: "Segoe UI";
+            font-size: 46px;
+            font-weight: 300;
+            line-height: 62px;
+        }
+
+        .main-text {
+            color: #808080;
+            font-size: 24px;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+        }
+
+        .main-text-p1 {
+            padding-top: 48px;
+            padding-bottom: 28px;
+        }
+
+        .endpoint {
+            height: 32px;
+            width: 571px;
+            color: #808080;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+            padding-top: 28px;
+        }
+
+        .how-to-build-section {
+            padding-top: 20px;
+            padding-left: 30px;
+        }
+
+        .how-to-build-section>h3 {
+            font-size: 16px;
+            font-weight: 600;
+            letter-spacing: 0.35px;
+            line-height: 22px;
+            margin: 0 0 24px 0;
+            text-transform: uppercase;
+        }
+
+        .step-container {
+            display: flex;
+            align-items: stretch;
+            position: relative;
+        }
+
+        .step-container dl {
+            border-left: 1px solid #A0A0A0;
+            display: block;
+            padding: 0 24px;
+            margin: 0;
+        }
+
+        .step-container dl>dt::before {
+            background-color: white;
+            border: 1px solid #A0A0A0;
+            border-radius: 100%;
+            content: '';
+            left: 47px;
+            height: 11px;
+            position: absolute;
+            width: 11px;
+        }
+
+        .step-container dl>.test-bullet::before {
+            background-color: blue;
+        }
+
+        .step-container dl>dt {
+            display: block;
+            font-size: inherit;
+            font-weight: bold;
+            line-height: 20px;
+        }
+
+        .step-container dl>dd {
+            font-size: inherit;
+            line-height: 20px;
+            margin-left: 0;
+            padding-bottom: 32px;
+        }
+
+        .step-container:last-child dl {
+            border-left: 1px solid transparent;
+        }
+
+        .ctaLink {
+            background-color: transparent;
+            border: 1px solid transparent;
+            color: #006AB1;
+            cursor: pointer;
+            font-weight: 600;
+            padding: 0;
+            white-space: normal;
+        }
+
+        .ctaLink:focus {
+            outline: 1px solid #00bcf2;
+        }
+
+        .ctaLink:hover {
+            text-decoration: underline;
+        }
+
+        .step-icon {
+            display: flex;
+            height: 38px;
+            margin-right: 15px;
+            width: 38px;
+        }
+
+        .step-icon>div {
+            height: 30px;
+            width: 30px;
+            background-repeat: no-repeat;
+        }
+
+        .ms-logo-container {
+            min-width: 580px;
+            max-width: 980px;
+            margin-left: auto;
+            margin-right: auto;
+            left: 0;
+            right: 0;
+            transition: bottom 400ms;
+        }
+
+        .ms-logo {
+            float: right;
+            background-image: url("data:image/svg+xml;utf8,%0A%3Csvg%20version%3D%221.1%22%20id%3D%22MS-symbol%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20400%20120%22%20style%3D%22enable-background%3Anew%200%200%20400%20120%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23737474%3B%7D%0A%09.st2%7Bfill%3A%23D63F26%3B%7D%0A%09.st3%7Bfill%3A%23167D3E%3B%7D%0A%09.st4%7Bfill%3A%232E76BC%3B%7D%0A%09.st5%7Bfill%3A%23FDB813%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.6%22%20class%3D%22st0%22%20width%3D%22398.7%22%20height%3D%22119%22/%3E%0A%3Cpath%20class%3D%22st1%22%20d%3D%22M171.3%2C38.4v43.2h-7.5V47.7h-0.1l-13.4%2C33.9h-5l-13.7-33.9h-0.1v33.9h-6.9V38.4h10.8l12.4%2C32h0.2l13.1-32H171.3%0A%09z%20M177.6%2C41.7c0-1.2%2C0.4-2.2%2C1.3-3c0.9-0.8%2C1.9-1.2%2C3.1-1.2c1.3%2C0%2C2.4%2C0.4%2C3.2%2C1.3c0.8%2C0.8%2C1.3%2C1.8%2C1.3%2C3c0%2C1.2-0.4%2C2.2-1.3%2C3%0A%09c-0.9%2C0.8-1.9%2C1.2-3.2%2C1.2s-2.3-0.4-3.1-1.2C178%2C43.8%2C177.6%2C42.8%2C177.6%2C41.7z%20M185.7%2C50.6v31h-7.3v-31H185.7z%20M207.8%2C76.3%0A%09c1.1%2C0%2C2.3-0.3%2C3.6-0.8c1.3-0.5%2C2.5-1.2%2C3.6-2v6.8c-1.2%2C0.7-2.5%2C1.2-4%2C1.5c-1.5%2C0.3-3.1%2C0.5-4.9%2C0.5c-4.6%2C0-8.3-1.4-11.1-4.3%0A%09c-2.9-2.9-4.3-6.6-4.3-11c0-5%2C1.5-9.1%2C4.4-12.3c2.9-3.2%2C7-4.8%2C12.4-4.8c1.4%2C0%2C2.7%2C0.2%2C4.1%2C0.5c1.4%2C0.4%2C2.5%2C0.8%2C3.3%2C1.2v7%0A%09c-1.1-0.8-2.3-1.5-3.4-1.9c-1.2-0.5-2.4-0.7-3.6-0.7c-2.9%2C0-5.2%2C0.9-7%2C2.8c-1.8%2C1.9-2.7%2C4.4-2.7%2C7.6c0%2C3.1%2C0.8%2C5.6%2C2.5%2C7.3%0A%09C202.6%2C75.4%2C204.9%2C76.3%2C207.8%2C76.3z%20M235.7%2C50.1c0.6%2C0%2C1.1%2C0%2C1.6%2C0.1s0.9%2C0.2%2C1.2%2C0.3v7.4c-0.4-0.3-0.9-0.5-1.7-0.8%0A%09c-0.7-0.3-1.6-0.4-2.7-0.4c-1.8%2C0-3.3%2C0.8-4.5%2C2.3c-1.2%2C1.5-1.9%2C3.8-1.9%2C7v15.6h-7.3v-31h7.3v4.9h0.1c0.7-1.7%2C1.7-3%2C3-4%0A%09C232.2%2C50.6%2C233.8%2C50.1%2C235.7%2C50.1z%20M238.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3%0A%09c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5c-4.8%2C0-8.6-1.4-11.4-4.2C240.3%2C75.3%2C238.9%2C71.4%2C238.9%2C66.6z%0A%09%20M246.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5%0A%09c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7C247.2%2C60.5%2C246.5%2C63%2C246.5%2C66.3z%20M281.5%2C58.8c0%2C1%2C0.3%2C1.9%2C1%2C2.5%0A%09c0.7%2C0.6%2C2.1%2C1.3%2C4.4%2C2.2c2.9%2C1.2%2C5%2C2.5%2C6.1%2C3.9c1.2%2C1.5%2C1.8%2C3.2%2C1.8%2C5.3c0%2C2.9-1.1%2C5.3-3.4%2C7c-2.2%2C1.8-5.3%2C2.7-9.1%2C2.7%0A%09c-1.3%2C0-2.7-0.2-4.3-0.5c-1.6-0.3-2.9-0.7-4-1.2v-7.2c1.3%2C0.9%2C2.8%2C1.7%2C4.3%2C2.2c1.5%2C0.5%2C2.9%2C0.8%2C4.2%2C0.8c1.6%2C0%2C2.9-0.2%2C3.6-0.7%0A%09c0.8-0.5%2C1.2-1.2%2C1.2-2.3c0-1-0.4-1.9-1.2-2.5c-0.8-0.7-2.4-1.5-4.6-2.4c-2.7-1.1-4.6-2.4-5.7-3.8c-1.1-1.4-1.7-3.2-1.7-5.4%0A%09c0-2.8%2C1.1-5.1%2C3.3-6.9c2.2-1.8%2C5.1-2.7%2C8.6-2.7c1.1%2C0%2C2.3%2C0.1%2C3.6%2C0.4c1.3%2C0.2%2C2.5%2C0.6%2C3.4%2C0.9v6.9c-1-0.6-2.1-1.2-3.4-1.7%0A%09c-1.3-0.5-2.6-0.7-3.8-0.7c-1.4%2C0-2.5%2C0.3-3.2%2C0.8C281.9%2C57.1%2C281.5%2C57.8%2C281.5%2C58.8z%20M297.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2%0A%09c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5%0A%09c-4.8%2C0-8.6-1.4-11.4-4.2C299.4%2C75.3%2C297.9%2C71.4%2C297.9%2C66.6z%20M305.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6%0A%09c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7%0A%09C306.3%2C60.5%2C305.5%2C63%2C305.5%2C66.3z%20M353.9%2C56.6h-10.9v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.3%2C1.1-5.9%2C3.2-8c2.1-2.1%2C4.8-3.1%2C8.1-3.1%0A%09c0.9%2C0%2C1.7%2C0%2C2.4%2C0.1c0.7%2C0.1%2C1.3%2C0.2%2C1.8%2C0.4V42c-0.2-0.1-0.7-0.3-1.3-0.5c-0.6-0.2-1.3-0.3-2.1-0.3c-1.5%2C0-2.7%2C0.5-3.5%2C1.4%0A%09s-1.2%2C2.4-1.2%2C4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4v14.5c0%2C1.9%2C0.3%2C3.3%2C1%2C4c0.7%2C0.8%2C1.8%2C1.2%2C3.3%2C1.2c0.4%2C0%2C0.9-0.1%2C1.5-0.3%0A%09c0.6-0.2%2C1.1-0.4%2C1.6-0.7v6c-0.5%2C0.3-1.2%2C0.5-2.3%2C0.7c-1.1%2C0.2-2.1%2C0.3-3.2%2C0.3c-3.1%2C0-5.4-0.8-6.9-2.5c-1.5-1.6-2.3-4.1-2.3-7.4%0A%09V56.6z%22/%3E%0A%3Cg%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2224%22%20class%3D%22st2%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2224%22%20class%3D%22st3%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2261.8%22%20class%3D%22st4%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2261.8%22%20class%3D%22st5%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+        }
+
+        .ms-logo-container>div {
+            min-height: 60px;
+            width: 150px;
+            background-repeat: no-repeat;
+        }
+
+        .row {
+            padding: 90px 0px 0 20px;
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .column {
+            float: left;
+            width: 45%;
+            padding-right: 20px;
+        }
+
+        .row:after {
+            content: "";
+            display: table;
+            clear: both;
+        }
+
+        a {
+            text-decoration: none;
+        }
+
+        .download-the-emulator {
+            height: 20px;
+            color: #0063B1;
+            font-size: 15px;
+            line-height: 20px;
+            padding-bottom: 70px;
+        }
+
+        .how-to-iframe {
+            max-width: 700px !important;
+            min-width: 650px !important;
+            height: 700px !important;
+        }
+
+        .remove-frame-height {
+            height: 10px;
+        }
+
+        @media only screen and (max-width: 1300px) {
+            .ms-logo {
+                padding-top: 30px;
+            }
+
+            .header-text {
+                font-size: 40x;
+            }
+
+            .column {
+                float: none;
+                padding-top: 30px;
+                width: 100%;
+            }
+
+            .ms-logo-container {
+                padding-top: 30px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+
+            .row {
+                padding: 20px 0px 0 20px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+
+        @media only screen and (max-width: 1370px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+        }
+
+        @media only screen and (max-width: 1230px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+
+            .header-text {
+                font-size: 44px;
+            }
+
+            .header-icon {
+                height: 120px;
+                width: 120px;
+            }
+        }
+
+        @media only screen and (max-width: 1000px) {
+            header {
+                background-color: #55A0E0;
+                background-image: none;
+            }
+        }
+
+        @media only screen and (max-width: 632px) {
+            .header-text {
+                font-size: 32px;
+            }
+
+            .row {
+                padding: 10px 0px 0 10px;
+                max-width: 490px !important;
+                min-width: 410px !important;
+            }
+
+            .endpoint {
+                font-size: 25px;
+            }
+
+            .main-text {
+                font-size: 20px;
+            }
+
+            .step-container dl>dd {
+                font-size: 14px;
+            }
+
+            .column {
+                padding-right: 5px;
+            }
+
+            .header-icon {
+                height: 110px;
+                width: 110px;
+            }
+
+            .how-to-iframe {
+                max-width: 480px !important;
+                min-width: 400px !important;
+                height: 650px !important;
+                overflow: hidden;
+            }
+        }
+
+        .remove-frame-height {
+            max-height: 10px;
+        }
+    </style>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            loadFrame();
+        });
+        var loadFrame = function () {
+            var iframe = document.createElement('iframe');
+            iframe.setAttribute("id", "iframe");
+            var offLineHTMLContent = "";
+            var frameElement = document.getElementById("how-to-iframe");
+            if (window.navigator.onLine) {
+                iframe.src = 'https://docs.botframework.com/static/abs/pages/f5.htm';
+                iframe.setAttribute("scrolling", "no");
+                iframe.setAttribute("frameborder", "0");
+                iframe.setAttribute("width", "100%");
+                iframe.setAttribute("height", "100%");
+                var frameDiv = document.getElementById("how-to-iframe");
+                frameDiv.appendChild(iframe);
+            } else {
+                frameElement.classList.add("remove-frame-height");
+            }
+        };
+    </script>
+</head>
+
+<body>
+    <header class="header">
+        <div class="header-inner-container">
+            <div class="header-icon" style="display: inline-block"></div>
+            <div class="header-text" style="display: inline-block">EchoBot Bot</div>
+        </div>
+    </header>
+    <div class="row">
+        <div class="column" class="main-content-area">
+            <div class="content-title">Your bot is ready!</div>
+            <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
+                by connecting to http://localhost:3978/api/messages.</div>
+            <div class="main-text download-the-emulator"><a class="ctaLink"
+                    href="https://aka.ms/bot-framework-F5-download-emulator" target="_blank">Download the Emulator</a>
+            </div>
+            <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home"
+                    target="_blank">Azure
+                    Bot Service</a> to register your bot and add it to<br />
+                various channels. The bot's endpoint URL typically looks
+                like this:</div>
+            <div class="endpoint">https://<i>your_bots_hostname</i>/api/messages</div>
+        </div>
+        <div class="column how-to-iframe" id="how-to-iframe"></div>
+    </div>
+    <div class="ms-logo-container">
+        <div class="ms-logo"></div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
Simple to use twitter adapter that allows connecting direct messages from twitter account to the bot framework.
There's a README.md file that explains in details how to configure this and what each configuration option means.
A sample project also shows how this can be used with a simple echo bot.

The twitter adapter is ready to be packaged with the CI already in place. Once the package is in Nuget, I will update the sample to use that package.
I will probably be submitting some updates to it with extended support for adaptive cards as I move along.

Relates to #105 
