### PR TITLE
Process twitter adapter calls through middleware pipeline

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Twitter/ApplicationBuilderExtensions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/ApplicationBuilderExtensions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using Bot.Builder.Community.Adapters.Twitter;
 using Bot.Builder.Community.Adapters.Twitter.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
-namespace Bot.Builder.Community.Adapters.Twitter
+namespace Microsoft.AspNetCore.Builder
 {
     public static class ApplicationBuilderExtensions
     {

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Bot.Builder.Community.Adapters.Twitter.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Bot.Builder.Community.Adapters.Twitter.csproj
@@ -10,6 +10,18 @@
     <Product />
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Documentation|AnyCPU' ">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug - NuGet Packages|AnyCPU' ">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.5.1" />

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Hosting/WebhookMiddleware.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Hosting/WebhookMiddleware.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
@@ -58,15 +60,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Hosting
                 || !_options.AllowedUsernamesConfigured())
             {
                 // Only respond if sender is different than the bot
-                await _bot.OnTurnAsync(new TurnContext(_adapter, new Activity
-                {
-                    Text = obj.MessageText,
-                    Type = "message",
-                    From = new ChannelAccount(obj.Sender.Id, obj.Sender.ScreenName),
-                    Recipient = new ChannelAccount(obj.Recipient.Id, obj.Recipient.ScreenName),
-                    Conversation = new ConversationAccount {Id = obj.Sender.Id},
-                    ChannelId = "twitter"
-                }));
+                await _adapter.ProcessActivity(obj, _bot.OnTurnAsync);
             }
         }
     }

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/ServiceCollectionExtensions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using Bot.Builder.Community.Adapters.Twitter;
 using Bot.Builder.Community.Adapters.Twitter.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Bot.Builder.Community.Adapters.Twitter
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterAdapter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
@@ -19,6 +20,12 @@ namespace Bot.Builder.Community.Adapters.Twitter
             _sender = new DirectMessageSender(options.Value);
         }
 
+        public new TwitterAdapter Use(IMiddleware middleware)
+        {
+            MiddlewareSet.Use(middleware);
+            return this;
+        }
+
         public override async Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext,
             Activity[] activities, CancellationToken cancellationToken)
         {
@@ -30,6 +37,39 @@ namespace Bot.Builder.Community.Adapters.Twitter
             }
 
             return responses.ToArray();
+        }
+
+        public async Task ProcessActivity(DirectMessageEvent obj, BotCallbackHandler callback)
+        {
+            TurnContext context = null;
+
+            try
+            {
+                var activity = RequestToActivity(obj);
+                BotAssert.ActivityNotNull(activity);
+
+                context = new TurnContext(this, activity);
+                
+                await RunPipelineAsync(context, callback, default).ConfigureAwait(false); 
+            }
+            catch (Exception ex)
+            {
+                await OnTurnError(context, ex);
+                throw;
+            }
+        }
+
+        private Activity RequestToActivity(DirectMessageEvent obj)
+        {
+            return new Activity
+            {
+                Text = obj.MessageText,
+                Type = "message",
+                From = new ChannelAccount(obj.Sender.Id, obj.Sender.ScreenName),
+                Recipient = new ChannelAccount(obj.Recipient.Id, obj.Recipient.ScreenName),
+                Conversation = new ConversationAccount { Id = obj.Sender.Id },
+                ChannelId = "twitter"
+            };
         }
 
         public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterAdapter.cs
@@ -30,7 +30,7 @@ namespace Bot.Builder.Community.Adapters.Twitter
             Activity[] activities, CancellationToken cancellationToken)
         {
             var responses = new List<ResourceResponse>();
-            foreach (var activity in activities)
+            foreach (var activity in activities.Where(a => a.Type == ActivityTypes.Message))
             {
                 await _sender.SendAsync(activity.AsTwitterMessage());
                 responses.Add(new ResourceResponse(activity.Id));


### PR DESCRIPTION
Refactor some of the Twitter Adapter processing, to invoke bot pipeline and bring code patterns closer to other adapters.

Fixes #141 