### PR TITLE
Fix for resetting form state

### DIFF
--- a/libraries/Bot.Builder.Community.Dialogs.FormFlow/FormDialog.cs
+++ b/libraries/Bot.Builder.Community.Dialogs.FormFlow/FormDialog.cs
@@ -223,6 +223,7 @@ namespace Bot.Builder.Community.Dialogs.FormFlow
 
         public async override Task<DialogTurnResult> BeginDialogAsync(DialogContext outerDc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+             _formState.Reset();
             if (this._entities.Any())
             {
                 var inputs = new List<Tuple<int, string>>();
@@ -256,9 +257,7 @@ namespace Bot.Builder.Community.Dialogs.FormFlow
                 }
             }
             await SkipSteps();
-            _formState.Step = 0;
-            _formState.StepState = null;
-
+           
             //var result = await base.BeginDialogAsync(outerDc, options, cancellationToken);
             var result = await MessageReceived(outerDc, outerDc.Context.Activity);
 


### PR DESCRIPTION
This commit is fix to reset the form state on begindialog and it will fix [BotBuilderCommunity/botbuilder-community-dotnet] Formflow data gets recreated on successive calls (call to 2nd step) to form steps (#144)