### PR TITLE
Pavolum/adapter enhancements

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapter.cs
@@ -119,7 +119,7 @@ namespace Bot.Builder.Community.Adapters.Alexa
             try
             {
                 var activities = Responses.ContainsKey(key) ? Responses[key] : new List<Activity>();
-                var response = CreateResponseFromActivity(activities, context);
+                var response = CreateResponseFromActivity(processMultipleActivities(activities), context);
                 return response;
             }
             finally
@@ -212,10 +212,8 @@ namespace Bot.Builder.Community.Adapters.Alexa
             }
         }
 
-        private SkillResponse CreateResponseFromActivity(List<Activity> activities, ITurnContext context)
+        private SkillResponse CreateResponseFromActivity(Activity activity, ITurnContext context)
         {
-            Activity activity = processMultipleActivities(activities);
-
             var response = new SkillResponse()
             {
                 Version = "1.0",

--- a/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapterOptions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapterOptions.cs
@@ -8,8 +8,6 @@
 
         public bool ShouldEndSessionByDefault { get; set; } = true;
 
-        public bool TryConvertSuggestedActionsToText { get; set; } = false;
-
         public bool TryConcatenateTextFromMultipleActivities { get; set; } = false;
 
     }

--- a/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapterOptions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapterOptions.cs
@@ -10,7 +10,7 @@
 
         public bool TryConvertSuggestedActionsToText { get; set; } = false;
 
-        public bool TryConcatMultipleTextActivties { get; set; } = false;
+        public bool TryConcatenateTextFromMultipleActivities { get; set; } = false;
 
     }
 }

--- a/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapterOptions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapterOptions.cs
@@ -7,5 +7,10 @@
         public bool ValidateIncomingAlexaRequests { get; set; } = true;
 
         public bool ShouldEndSessionByDefault { get; set; } = true;
+
+        public bool TryConvertSuggestedActionsToText { get; set; } = false;
+
+        public bool TryConcatMultipleTextActivties { get; set; } = false;
+
     }
 }

--- a/libraries/Bot.Builder.Community.Adapters.Google/GoogleAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Google/GoogleAdapter.cs
@@ -20,6 +20,7 @@ namespace Bot.Builder.Community.Adapters.Google
         public bool ShouldEndSessionByDefault { get; set; }
 
         public bool TryConvertFirstActivityAttachmentToGoogleCard { get; set; }
+        public bool TryConcatMultipleTextActivties { get; set; }
 
         public string ActionInvocationName { get; set; }
 
@@ -31,6 +32,7 @@ namespace Bot.Builder.Community.Adapters.Google
         {
             ShouldEndSessionByDefault = true;
             TryConvertFirstActivityAttachmentToGoogleCard = false;
+            TryConcatMultipleTextActivties = false;
         }
 
         public new GoogleAdapter Use(IMiddleware middleware)
@@ -305,7 +307,7 @@ namespace Bot.Builder.Community.Adapters.Google
 
         private DialogFlowResponseBody CreateDialogFlowResponseFromLastActivity(IEnumerable<Activity> activities, ITurnContext context)
         {
-            var activity = processMultipleActivities(activities.ToList());
+            var activity = activities != null && activities.Any() ? processMultipleActivities(activities.ToList()) : null;
 
             var response = new DialogFlowResponseBody()
             {
@@ -463,7 +465,7 @@ namespace Bot.Builder.Community.Adapters.Google
         private Activity processMultipleActivities(List<Activity> activities)
         {
             Activity resultActivity = activities.Last();
-            if (/*_options.TryConcatMultipleTextActivties &&*/ activities.Count() > 1)
+            if (TryConcatMultipleTextActivties && activities.Count() > 1)
             {
                 for (int i = activities.Count - 2; i >= 0; i--)
                 {


### PR DESCRIPTION
This PR contains the following:

- Alexa adapter now converts BF suggested actions to a numbered list and appends that numbered list string to the end of the text response 
  - Addition of configurable flag that tells the adapter whether or not it should do this conversion
- Google adapter now converts suggested actions in a BF activity to Google Home 'suggestionChips'
- Alexa and Google adapter now checks if more then one activity is being sent from the bot to the user in a single turn. If there is more then one activity and those activities have text or speech values then the text/speech values are concatenated to a single activity which is returned to the user. 
  - Addition of configurable flag that dictates whether or not the adapter should do this conversion

NOTE: The message concat function to handle multiple message activities is nearly identical for both adapters. It may make sense to put this in a shared project if it is likely that this type of helper function is adapter agnostic
