### PR TITLE
Added AdaptiveCardPrompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ This repository is part of the Bot Builder Community Project and contains Bot Bu
 
 To see a list of current extensions available for the Bot Builder .NET SDK, use the links below to jump to a section.
 
-* [C# Middleware](#middleware)
-* [C# Dialogs & Prompts](#dialogs-and-prompts)
-* [C# Adapters](#adapters) - e.g. Alexa, Google and Twitter DMs
-* [C# Recognizers](#recognizers)
-* [C# Storage](#storage) 
+- [Bot Builder Community - .NET Extensions](#bot-builder-community---net-extensions)
+  - [Installation](#installation)
+  - [Contributing and Reporting Issues](#contributing-and-reporting-issues)
+  - [Middleware](#middleware)
+  - [Dialogs and Prompts](#dialogs-and-prompts)
+  - [Adapters](#adapters)
+  - [Recognizers](#recognizers)
+  - [Storage](#storage)
 
 ## Installation
 
@@ -41,7 +44,7 @@ The following dialogs are currently available;
 | [Bot Builder v4 Location Dialog](libraries/Bot.Builder.Community.Dialogs.Location) | An implemention for v4 of the Bot Build .NET SDK of the [Microsoft.Bot.Builder.Location dialog project built for Bot Builder v3](https://github.com/microsoft/botbuilder-location). An open-source location picker control for Microsoft Bot Framework powered by Azure or Bing Maps REST services. This control will allow a user to search for a location, with the ability to specify required fields and also store locations as favorites for the user. | [Sample](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/master/samples/Location%20Dialog%20Sample) | [![NuGet version](https://img.shields.io/badge/NuGet-1.0.100-blue.svg)](https://www.nuget.org/packages/Bot.Builder.Community.Dialogs.Location/) |
 | [Bot Builder ChoiceFlow](libraries/Bot.Builder.Community.Dialogs.ChoiceFlow) |This dialog allows you to provide the user with a series of guides choice prompts in turn (defined in a JSON file or as a collection of ChoiceFlowItem objects), similar to when calling a telephone line with a series of automated options. The dialog returns the user's last choice as a result from the dialog and optionally provide the user with a simple text response depending on which choice they land on. | [Sample](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/master/samples/ChoiceFlow%20Dialog%20Sample) | [![NuGet version](https://img.shields.io/badge/NuGet-1.0.0-blue.svg)](https://www.nuget.org/packages/Bot.Builder.Community.Dialogs.ChoiceFlow/) |
 | [Bot Builder v4 FormFlow](libraries/Bot.Builder.Community.Dialogs.FormFlow) | An implemention for v4 of the Bot Build .NET SDK of the [Microsoft.Bot.Builder.FormFlow dialog project built for Bot Builder v3](https://github.com/Microsoft/BotBuilder-V3/tree/master/CSharp/Library/Microsoft.Bot.Builder/FormFlow). FormFlow automatically generates the dialogs that are necessary to manage a guided conversation, based upon guidelines you specify. | [Sample](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/master/samples/Form%20Flow%20Sample) | [![NuGet version](https://img.shields.io/badge/NuGet-1.0.0-blue.svg)](https://www.nuget.org/packages/Bot.Builder.Community.Dialogs.FormFlow/) |
-| [Bot Builder v4 Prompts](libraries/Bot.Builder.Community.Dialogs.Prompts) | A collection of Prompts for use with Bot Builder v4, providing the ability to prompt for and recognize currencies, age, distances and temperature. | | [![NuGet version](https://img.shields.io/badge/NuGet-1.0.79-blue.svg)](https://www.nuget.org/packages/Bot.Builder.Community.Dialogs.Prompts/) |
+| [Bot Builder v4 Prompts](libraries/Bot.Builder.Community.Dialogs.Prompts) | A collection of Prompts for use with Bot Builder v4, providing the ability to prompt using Adaptive Cards and for recognizing currencies, age, distances and temperature. | | [![NuGet version](https://img.shields.io/badge/NuGet-1.0.79-blue.svg)](https://www.nuget.org/packages/Bot.Builder.Community.Dialogs.Prompts/) |
 | [Bot Builder v4 Luis Dialog](libraries/Bot.Builder.Community.Dialogs.Luis) | An implementation for v4 of the Bot Builder .NET SDK of the [Microsoft.Bot.Builder.Dialogs.LuisDialog built for Bot Builder V3](https://github.com/microsoft/BotBuilder-V3/tree/master/CSharp/Library/Microsoft.Bot.Builder/Luis) A dialog specialized to handle intents and entities from LUIS. | [Sample](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/master/samples/Luis%20Dialog%20Sample) | [![NuGet version](https://img.shields.io/badge/NuGet-1.0.79-blue.svg)](https://www.nuget.org/packages/Bot.Builder.Community.Dialogs.Luis/) |
 
 ## Adapters

--- a/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPrompt.cs
+++ b/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPrompt.cs
@@ -1,0 +1,256 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json.Linq;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+
+namespace Bot.Builder.Community.Dialogs.Prompts
+{
+    public enum AdaptiveCardPromptErrors
+    {
+        /// <summary>
+        /// No known user errors.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Error presented if developer specifies AdaptiveCardPromptSettings.promptId,
+        /// but user submits adaptive card input on a card where the ID does not match.
+        /// This error will also be present if developer AdaptiveCardPromptSettings.promptId,
+        /// but forgets to add the promptId to every <submit>.data.promptId in your Adaptive Card.
+        /// </summary>
+        UserInputDoesNotMatchCardId,
+
+        /// <summary>
+        /// Error presented if developer specifies AdaptiveCardPromptSettings.requiredIds,
+        /// but user does not submit input for all required input id's on the adaptive card.
+        /// </summary>
+        MissingRequiredIds,
+
+        /// <summary>
+        /// Error presented if user enters plain text instead of using Adaptive Card's input fields.
+        /// </summary>
+        UserUsedTextInput,
+    }
+
+    /// <summary>
+    /// Waits for Adaptive Card Input to be received.
+    /// </summary>
+    /// <remarks>
+    /// This prompt is similar to ActivityPrompt but provides features specific to Adaptive Cards:
+    ///   * Optionally allow specified input fields to be required
+    ///   * Optionally ensures input is only valid if it comes from the appropriate card (not one shown previous to prompt)
+    ///   * Provides ability to handle variety of common user errors related to Adaptive Cards
+    /// DO NOT USE WITH CHANNELS THAT DON'T SUPPORT ADAPTIVE CARDS.
+    /// </remarks>
+    public class AdaptiveCardPrompt : Dialog
+    {
+        private const string PersistedOptions = "options";
+        private const string PersistedState = "state";
+        public const string AttemptCountKey = "AttemptCount";
+
+        // Has to be dynamic because PromptValidator is internal to the SDK
+        private readonly AdaptiveCardPromptValidator<AdaptiveCardPromptResult> _validator;
+        private readonly string[] _requiredInputIds;
+        private readonly string _promptId;
+        private readonly Attachment _card;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdaptiveCardPrompt"/> class.
+        /// </summary>
+        /// <param name="dialogId">Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.</param>
+        /// <param name="validator">(optional) Validator that will be called each time a new activity is received.</param>
+        /// <param name="settings">(optional) Additional settings for AdaptiveCardPrompt behavior.</param>
+        public AdaptiveCardPrompt(string dialogId, AdaptiveCardPromptSettings settings, AdaptiveCardPromptValidator<AdaptiveCardPromptResult> validator = null)
+            : base(dialogId)
+        {
+            if (settings == null || settings.Card == null)
+            {
+                throw new ArgumentNullException("AdaptiveCardPrompt requires a card in `AdaptiveCardPromptSettings.card`");
+            }
+
+            _validator = validator;
+
+            _requiredInputIds = settings.RequiredInputIds ?? null;
+
+            ThrowIfNotAdaptiveCard(settings.Card);
+            _card = settings.Card;
+
+            _promptId = settings.PromptId;
+        }
+
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Initialize prompt state
+            var state = dc.ActiveDialog.State;
+            state[PersistedOptions] = options;
+            state[PersistedState] = new Dictionary<string, object>
+            {
+                { AttemptCountKey, 0 },
+            };
+
+            // Send initial prompt
+            await OnPromptAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions], false, cancellationToken).ConfigureAwait(false);
+
+            return Dialog.EndOfTurn;
+        }
+
+        // Override ContinueDialogAsync so that we can catch Activity.Value (which is ignored, by default)
+        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken)
+        {
+            // Perform base recognition
+            var instance = dc.ActiveDialog;
+            var state = (IDictionary<string, object>)instance.State[PersistedState];
+            var options = (PromptOptions)instance.State[PersistedOptions];
+            var recognized = await OnRecognizeAsync(dc.Context, cancellationToken).ConfigureAwait(false);
+
+            // Increment attempt count
+            // Convert.ToInt32 For issue https://github.com/Microsoft/botbuilder-dotnet/issues/1859
+            state[AttemptCountKey] = Convert.ToInt32(state[AttemptCountKey]) + 1;
+
+            var isValid = false;
+            if (_validator != null)
+            {
+                var promptContext = new AdaptiveCardPromptValidatorContext<AdaptiveCardPromptResult>(dc.Context, recognized, state, options);
+                isValid = await _validator(promptContext, cancellationToken).ConfigureAwait(false);
+            } 
+            else if (recognized.Succeeded)
+            {
+                isValid = true;
+            }
+
+            // Return recognized value or re-prompt
+            if (isValid)
+            {
+                return await dc.EndDialogAsync(recognized.Value).ConfigureAwait(false);
+            }
+            else
+            {
+                // Re-prompt
+                if (!dc.Context.Responded)
+                {
+                    await OnPromptAsync(dc.Context, state, options, true, cancellationToken).ConfigureAwait(false);
+                }
+
+                return Dialog.EndOfTurn;
+            }
+        }
+
+        protected virtual async Task OnPromptAsync(ITurnContext context, IDictionary<string, object> state, PromptOptions options, bool isRetry, CancellationToken cancellationToken)
+        {
+            // Since card is passed in via AdaptiveCardPromptSettings, PromptOptions may not be used.
+            // Ensure we're working with RetryPrompt, as applicable
+            var prompt = isRetry && options.RetryPrompt != null ? options.RetryPrompt : options.Prompt;
+
+            // Clone the correct prompt (or new Activity, if null) so that we don't affect the one saved in state
+            var clonedPrompt = JObject.FromObject(prompt ?? new Activity()).ToObject<Activity>();
+
+            // The actual AdaptiveCard should be tightly-coupled to its AdaptiveCardPromptSettings, which means it would be instantiated in
+            //   a Dialog's constructor and passed in when using AddDialog(AdaptiveCardPrompt) as opposed to passing into Activity.Attachments.
+            //   The actual prompt is typically called by using stepContext.PromptAsync() in a WaterfallDialog step, where PromptOptions is
+            //   required by DialogContext. However, PromptOptions isn't really required (or useful) for AdaptiveCardPrompt.
+            // This next code block allows a user to simply call by setting Activity.Type to ActivityTypes.Message
+            // "PromptAsync(nameof(AdaptiveCardPrompt), new PromptOptions())", instead of the uglier
+            // "PromptAsync(nameof(AdaptiveCardPrompt), new PromptOptions(){ Prompt = MessageFactory.Text(string.Empty) })"
+            // Note: PromptOptions does not need to be set in Node, since it compiles to JavaScript
+            //   and the card gets sent without setting Activity.Type
+            if (clonedPrompt.Type == null)
+            {
+                clonedPrompt.Type = ActivityTypes.Message;
+            }
+
+            // Add Adaptive Card as last attachment (user input should go last), keeping any others
+            if (clonedPrompt.Attachments == null)
+            {
+                clonedPrompt.Attachments = new List<Attachment>();
+            }
+
+            clonedPrompt.Attachments.Add(_card);
+
+            await context.SendActivityAsync(clonedPrompt, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected virtual Task<PromptRecognizerResult<AdaptiveCardPromptResult>> OnRecognizeAsync(ITurnContext context, CancellationToken cancellationToken)
+        {
+            // Ignore user input that doesn't come from adaptive card
+            if (string.IsNullOrWhiteSpace(context.Activity.Text) && context.Activity.Value != null)
+            {
+                var data = JObject.FromObject(context.Activity.Value);
+
+                // Validate it comes from the correct card - This is only a worry while the prompt/dialog has not ended
+                if (!string.IsNullOrEmpty(_promptId) && data["promptId"]?.ToString() != _promptId)
+                {
+                    return Task.FromResult(new PromptRecognizerResult<AdaptiveCardPromptResult>() 
+                    { 
+                        Succeeded = false,
+                        Value = new AdaptiveCardPromptResult()
+                        {
+                            Data = data,
+                            Error = AdaptiveCardPromptErrors.UserInputDoesNotMatchCardId,
+                        },
+                    });
+                }
+
+                // Check for required input data, if specified in AdaptiveCardPromptSettings
+                var missingIds = new List<string>();
+                foreach (var id in _requiredInputIds ?? Enumerable.Empty<string>())
+                {
+                    if (data[id] == null || string.IsNullOrWhiteSpace(data[id].ToString()))
+                    {
+                        missingIds.Add(id);
+                    }
+                }
+
+                // User did not submit inputs that were required
+                if (missingIds.Count > 0)
+                {
+                    return Task.FromResult(new PromptRecognizerResult<AdaptiveCardPromptResult>()
+                    { 
+                        Succeeded = false,
+                        Value = new AdaptiveCardPromptResult()
+                        {
+                            Data = data,
+                            Error = AdaptiveCardPromptErrors.MissingRequiredIds,
+                            MissingIds = missingIds,
+                        },
+                    });
+                }
+
+                return Task.FromResult(new PromptRecognizerResult<AdaptiveCardPromptResult>()
+                {
+                    Succeeded = true,
+                    Value = new AdaptiveCardPromptResult() { Data = data },
+                });
+            }
+            else
+            {
+                // User used text input instead of card input
+                return Task.FromResult(new PromptRecognizerResult<AdaptiveCardPromptResult>() 
+                { 
+                    Succeeded = false,
+                    Value = new AdaptiveCardPromptResult() { Error = AdaptiveCardPromptErrors.UserUsedTextInput },
+                });
+            }
+        }
+
+        private void ThrowIfNotAdaptiveCard(Attachment cardAttachment)
+        {
+            var adaptiveCardType = "application/vnd.microsoft.card.adaptive";
+
+            if (cardAttachment == null || cardAttachment.Content == null)
+            {
+                throw new NullReferenceException($"No Adaptive Card provided. Include in the constructor or PromptOptions.Prompt.Attachments");
+            }
+            else if (string.IsNullOrEmpty(cardAttachment.ContentType) || cardAttachment.ContentType != adaptiveCardType)
+            {
+                throw new ArgumentException($"Attachment is not a valid Adaptive Card.\n" +
+                                    $"Ensure Card.ContentType is '${adaptiveCardType}'\n" +
+                                    "and Card.Content contains the card json");
+            }
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPromptResult.cs
+++ b/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPromptResult.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+
+namespace Bot.Builder.Community.Dialogs.Prompts
+{
+    /// <summary>
+    /// Represents a result from adaptive card input.
+    /// </summary>
+    /// <typeparam name="T">Type returned by recognizer.</typeparam>
+    public class AdaptiveCardPromptResult
+    {
+        /// <summary>
+        /// Gets or sets the Value of the Adaptive Card input.
+        /// </summary>
+        /// <value>
+        /// The value of the user's input from the Adaptive Card.
+        /// </value>
+        public object Data { get; set; }
+
+        /// <summary>
+        /// Gets or sets Error enum.
+        /// </summary>
+        /// <value>
+        /// If not recognized.succeeded, include reason why, if known.
+        /// </value>
+        public AdaptiveCardPromptErrors Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets array of missing required Ids.
+        /// </summary>
+        /// <value>
+        /// Array of requiredIds that were not included with user input.
+        /// </value>
+        public List<string> MissingIds { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPromptSettings.cs
+++ b/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPromptSettings.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.Bot.Schema;
+
+namespace Bot.Builder.Community.Dialogs.Prompts
+{
+    /// <summary>
+    /// Settings to control the behavior of AdaptiveCardPrompt.
+    /// </summary>
+    public class AdaptiveCardPromptSettings
+    {
+        /// <summary>
+        /// Gets or sets the card to send the user. Required.
+        /// </summary>
+        /// <remarks>
+        /// Add the card here. Do not pass it in to `Prompt.Attachments` or it will show twice.
+        /// </remarks>
+        /// <value>
+        /// An Adaptive Card. Can be input here or in constructor.
+        /// </value>
+        public Attachment Card { get; set; }
+
+        /// <summary>
+        /// Gets or sets the array of strings matching IDs of required input fields.
+        /// </summary>
+        /// <value>
+        /// The message sent (if not null) when user uses text input instead of Adaptive Card Input.
+        /// </value>
+        /// <remarks>
+        /// The ID strings must exactly match those used in the Adaptive Card JSON Input IDs
+        /// For JSON:
+        /// ```json
+        /// {
+        ///   "type": "Input.Text",
+        ///   "id": "myCustomId",
+        /// },
+        /// ```
+        ///   You would use `"myCustomId"` if you want that to be a required input.
+        /// </remarks>
+        public string[] RequiredInputIds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID specific to this prompt.
+        /// If used, you MUST add this promptId to every data.promptId in your Adaptive Card.
+        /// </summary>
+        /// <value>
+        /// The ID specific to this prompt.
+        /// </value>
+        /// <remarks>
+        /// Card input is only accepted if SubmitAction.data.promptId matches the promptId.
+        /// Does not change between reprompts.
+        /// </remarks>
+        public string PromptId { get; set; }
+    }
+}

--- a/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPromptValidator.cs
+++ b/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPromptValidator.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This is a copy/paste of PromptValidator<T> from the Bot Framework SDK
+// This must be used to to internal class sealing
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bot.Builder.Community.Dialogs.Prompts
+{
+    /// <summary>
+    /// The delegate definition for custom prompt validators. Implement this function to add custom validation to a prompt.
+    /// </summary>
+    /// <typeparam name="T">The type the associated <see cref="Prompt{T}"/> prompts for.</typeparam>
+    /// <param name="promptContext">The prompt validation context.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Task"/> of bool representing the asynchronous operation indicating validation success or failure.</returns>
+    public delegate Task<bool> AdaptiveCardPromptValidator<T>(AdaptiveCardPromptValidatorContext<T> promptContext, CancellationToken cancellationToken);
+}

--- a/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPromptValidatorContext.cs
+++ b/libraries/Bot.Builder.Community.Dialogs.Prompts/AdaptiveCardPromptValidatorContext.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This is a copy/paste of PromptValidatorContext<T> from the Bot Framework SDK
+// This must be used to to internal class sealing
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+
+namespace Bot.Builder.Community.Dialogs.Prompts
+{
+    /// <summary>
+    /// Contains context information for a <see cref="PromptValidator{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of value the prompt returns.</typeparam>
+    public class AdaptiveCardPromptValidatorContext<T>
+    {
+        internal AdaptiveCardPromptValidatorContext(ITurnContext turnContext, PromptRecognizerResult<T> recognized, IDictionary<string, object> state, PromptOptions options)
+        {
+            Context = turnContext;
+            Options = options;
+            Recognized = recognized;
+            State = state;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="TurnContext"/> for the current turn of conversation with the user.
+        /// </summary>
+        /// <value>Context for the current turn of conversation with the user.</value>
+        public ITurnContext Context { get; }
+
+        /// <summary>
+        /// Gets the <see cref="PromptRecognizerResult{T}"/> returned from the prompt's recognition attempt.
+        /// </summary>
+        /// <value>The recognition results from the prompt's recognition attempt.</value>
+        public PromptRecognizerResult<T> Recognized { get; }
+
+        /// <summary>
+        /// Gets the <see cref="PromptOptions"/> used for this recognition attempt.
+        /// </summary>
+        /// <value>The prompt options used for this recognition attempt.</value>
+        public PromptOptions Options { get; }
+
+        /// <summary>
+        /// Gets state for the associated prompt instance.
+        /// </summary>
+        /// <value>State for the associated prompt instance.</value>
+        public IDictionary<string, object> State { get; }
+
+        /// <summary>
+        /// Gets the number of times this instance of the prompt has been executed.
+        /// </summary>
+        /// <value>A number indicating how many times the prompt was invoked (starting at 1 for the first time it was called).</value>
+        /// <remarks>This count is set when the prompt is added to the dialog stack.</remarks>
+        public int AttemptCount
+        {
+            get
+            {
+                if (!State.ContainsKey(AdaptiveCardPrompt.AttemptCountKey))
+                {
+                    return 0;
+                }
+
+                return Convert.ToInt32(State[AdaptiveCardPrompt.AttemptCountKey]);
+            }
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Dialogs.Prompts/readme.md
+++ b/libraries/Bot.Builder.Community.Dialogs.Prompts/readme.md
@@ -15,6 +15,7 @@ Currently the following Prompts are available;
 | Prompt | Description |
 | ------ | ------ |
 | [Number with Unit](#number-with-unit-prompt) | Prompt a user for Currency, Temperature, Age, Dimension (distance). |
+| [Adaptive Card](#adaptive-card-prompt) | Prompt a user using an Adaptive Card. |
 
 ### Installation
 
@@ -75,3 +76,69 @@ Below is an example of how you might use this result.
 
 ```
 
+### Adaptive Card Prompt
+
+#### Features
+
+* Includes validation for specified required input fields
+* Displays custom message if user replies via text and not card input
+* Ensures input is only valid if it comes from the appropriate card (not one shown previous to prompt)
+
+#### Usage
+
+```csharp
+// Load an adaptive card
+const cardJson = require('./adaptiveCard.json');
+const card = CardFactory.adaptiveCard(cardJson);
+
+// Configure settings - All optional
+var promptSettings = new AdaptiveCardPromptSettings() {
+    Card: card,
+    InputFailMessage: 'Please fill out the adaptive card',
+    RequiredInputIds: [
+        'inputA',
+        'inputB',
+    ],
+    MissingRequiredInputsMessage: 'The following inputs are required',
+    AttemptsBeforeCardRedsiplayed: 5,
+    PromptId: 'myCustomId'
+}
+
+// Initialize the prompt
+var adaptiveCardPrompt = new AdaptiveCardPrompt('adaptiveCardPrompt', null, promptSettings);
+
+// Add the prompt to your dialogs
+dialogSet.add(adaptiveCardPrompt);
+
+// Call the prompt
+return await stepContext.prompt('adaptiveCardPrompt');
+
+// Use the result
+const result = stepContext.result;
+```
+
+#### Adaptive Cards
+
+Card authors describe their content as a simple JSON object. That content can then be rendered natively inside a host application, automatically adapting to the look and feel of the host. For example, Contoso Bot can author an Adaptive Card through the Bot Framework, and when delivered to Cortana, it will look and feel like a Cortana card. When that same payload is sent to Microsoft Teams, it will look and feel like Microsoft Teams. As more host apps start to support Adaptive Cards, that same payload will automatically light up inside these applications, yet still feel entirely native to the app. Users win because everything feels familiar. Host apps win because they control the user experience. Card authors win because their content gets broader reach without any additional work.
+
+The Bot Framework provides support for Adaptive Cards.  See the following to learn more about Adaptive Cards.
+
+- [Adaptive card](http://adaptivecards.io)
+- [Send an Adaptive card](https://docs.microsoft.com/en-us/azure/bot-service/nodejs/bot-builder-nodejs-send-rich-cards?view=azure-bot-service-3.0&viewFallbackFrom=azure-bot-service-4.0#send-an-adaptive-card)
+
+##### Getting Input Data From Adaptive Cards
+
+In a `TextPrompt`, the user response is returned in the `Activity.Text` property, which only accepts strings. Because Adaptive Cards can contain multiple inputs, the user response is sent as a JSON object in `Activity.Value`, like so:
+
+```json
+const activity = {
+    [...]
+    "value": {
+        "inputA": "response A",
+        "inputB": "response B",
+        [...etc]
+    }
+}
+```
+
+Because of this, it can be a little difficult to gather user input using an Adaptive Card within a dialog. The `AdaptiveCardPrompt` allows you to do so easily and returns the JSON object user response in `stepContext.result`.

--- a/tests/Bot.Builder.Community.Dialogs.Prompts.Tests/AdaptiveCardPromptTests.cs
+++ b/tests/Bot.Builder.Community.Dialogs.Prompts.Tests/AdaptiveCardPromptTests.cs
@@ -1,0 +1,855 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bot.Builder.Community.Dialogs.Prompts.Tests
+{
+    [TestClass]
+    public class AdaptiveCardPromptTests
+    {
+        private readonly string customPromptId = "custom";
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AdaptiveCardPromptWithoutSettingsShouldFail()
+        {
+            new AdaptiveCardPrompt("prompt", null);
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AdaptiveCardPromptWithoutCardShouldFail()
+        {
+            new AdaptiveCardPrompt("prompt", new AdaptiveCardPromptSettings());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NullReferenceException), "No Adaptive Card provided. Include in the constructor or PromptOptions.Prompt.Attachments")]
+        public void AdaptiveCardPromptWithBlankCardShouldFail()
+        {
+            new AdaptiveCardPrompt("prompt", new AdaptiveCardPromptSettings() { Card = new Attachment() });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void AdaptiveCardPromptWithoutValidCardShouldFail()
+        {
+            new AdaptiveCardPrompt("prompt", new AdaptiveCardPromptSettings()
+            {
+                Card = new Attachment()
+                {
+                    Content = GetCard().Content,
+                    ContentType = "invalidcard"
+                }
+            });
+        }
+
+        [TestMethod]
+        public async Task RecognizesInputWithCustomPromptIdAndCorrectInput()
+        {
+            var usedValidator = false;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt", 
+                new AdaptiveCardPromptSettings()
+                {
+                    PromptId = customPromptId,
+                    Card = GetCard(),
+                },
+                (context, cancel) =>
+                {
+                    Assert.IsTrue(context.Recognized.Succeeded);
+                    Assert.AreEqual(context.Recognized.Value.Error, AdaptiveCardPromptErrors.None);
+                    usedValidator = true;
+                    return Task.FromResult(context.Recognized.Succeeded);
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    var card = JObject.FromObject((activity as Activity).Attachments[0].Content);
+                    Assert.AreEqual(card["selectAction"]["data"]["promptId"], customPromptId);
+                })
+            .Send(simulatedInput)
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task PresentsPromptIdErrorWhenInputPromptIdDoesNotMatch()
+        {
+            var usedValidator = false;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt",
+                new AdaptiveCardPromptSettings()
+                {
+                    PromptId = "differentPromptId",
+                    Card = GetCard(),
+                },
+                (context, cancel) =>
+                {
+                    Assert.IsFalse(context.Recognized.Succeeded);
+                    Assert.AreEqual(context.Recognized.Value.Error, AdaptiveCardPromptErrors.UserInputDoesNotMatchCardId);
+                    usedValidator = true;
+                    return Task.FromResult(context.Recognized.Succeeded);
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    var card = JObject.FromObject((activity as Activity).Attachments[0].Content);
+                    Assert.AreEqual(card["selectAction"]["data"]["promptId"], customPromptId);
+                })
+            .Send(simulatedInput)
+            .AssertReply(
+                (activity) =>
+                {
+                    var card = JObject.FromObject((activity as Activity).Attachments[0].Content);
+                    Assert.AreEqual(card["selectAction"]["data"]["promptId"], customPromptId);
+                })
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task RecognizesIfAllRequiredIdsSupplied()
+        {
+            var usedValidator = false;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt",
+                new AdaptiveCardPromptSettings()
+                {
+                    Card = GetCard(),
+                    RequiredInputIds = new string[]
+                    {
+                        "foodChoice",
+                        "steakOther",
+                        "steakTemp",
+                    }
+                },
+                (context, cancel) =>
+                {
+                    Assert.IsTrue(context.Recognized.Succeeded);
+                    Assert.AreEqual(context.Recognized.Value.Error, AdaptiveCardPromptErrors.None);
+                    usedValidator = true;
+                    return Task.FromResult(context.Recognized.Succeeded);
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send(simulatedInput)
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task PresentsMissingIdsErrorWhenInputIsMissingIds()
+        {
+            var usedValidator = false;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt",
+                new AdaptiveCardPromptSettings()
+                {
+                    Card = GetCard(),
+                    RequiredInputIds = new string[]
+                    {
+                        "test1",
+                        "test2",
+                        "test3",
+                    }
+                },
+                async (context, cancel) =>
+                {
+                    Assert.IsFalse(context.Recognized.Succeeded);
+                    Assert.AreEqual(context.Recognized.Value.Error, AdaptiveCardPromptErrors.MissingRequiredIds);
+                    await context.Context.SendActivityAsync($"test inputs missing: {string.Join(", ", context.Recognized.Value.MissingIds)}");
+                    usedValidator = true;
+                    return context.Recognized.Succeeded;
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result.GetType().GetProperty("Data");
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send(simulatedInput)
+            .AssertReply("test inputs missing: test1, test2, test3")
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task RecognizesValidCardInput()
+        {
+            var usedValidator = false;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt",
+                new AdaptiveCardPromptSettings()
+                {
+                    Card = GetCard(),
+                },
+                (context, cancel) =>
+                {
+                    Assert.IsTrue(context.Recognized.Succeeded);
+                    usedValidator = true;
+                    return Task.FromResult(context.Recognized.Succeeded);
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send(simulatedInput)
+            .AssertReply($"You said: {simulatedInput.Value.ToString()}")
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task PresentsTextInputErrorWhenUserInputsViaTextNotCard()
+        {
+            var usedValidator = false;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt",
+                new AdaptiveCardPromptSettings()
+                {
+                    Card = GetCard(),
+                },
+                (context, cancel) =>
+                {
+                    Assert.IsFalse(context.Recognized.Succeeded);
+                    Assert.AreEqual(context.Recognized.Value.Error, AdaptiveCardPromptErrors.UserUsedTextInput);
+                    usedValidator = true;
+                    return Task.FromResult(context.Recognized.Succeeded);
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send("This is not valid card input")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task CallsUsingBeginDialog()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt", new AdaptiveCardPromptSettings() { Card = GetCard() });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.BeginDialogAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send(simulatedInput)
+            .AssertReply($"You said: {simulatedInput.Value.ToString()}")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task CallsUsingPrompt()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt", new AdaptiveCardPromptSettings() { Card = GetCard() });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send(simulatedInput)
+            .AssertReply($"You said: {simulatedInput.Value.ToString()}")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task UsesRetryPromptOnRetries()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt", new AdaptiveCardPromptSettings() { Card = GetCard() });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.BeginDialogAsync("prompt", new PromptOptions()
+                    {
+                        RetryPrompt = MessageFactory.Text("RETRY")
+                    });
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send("This is not a valid response")
+            .AssertReply("RETRY")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task DoesNotOverwriteDevProvidedAttachments()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt", new AdaptiveCardPromptSettings() { Card = GetCard() });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var promptWithAttachments = MessageFactory.Text(string.Empty);
+                    promptWithAttachments.Attachments = new List<Attachment>
+                    {
+                        new Attachment() { Content = "a" },
+                        new Attachment() { Content = "b" },
+                        new Attachment() { Content = "c" },
+                    };
+                    await dc.BeginDialogAsync("prompt", new PromptOptions()
+                    {
+                        Prompt = promptWithAttachments
+                    });
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => 
+            {
+                Assert.AreEqual((activity as Activity).Attachments[0].Content, "a");
+                Assert.AreEqual((activity as Activity).Attachments[1].Content, "b");
+                Assert.AreEqual((activity as Activity).Attachments[2].Content, "c");
+                Assert.AreEqual((activity as Activity).Attachments[3].ContentType, "application/vnd.microsoft.card.adaptive");
+            })
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task TracksTheNumberOfAttempts()
+        {
+            var attempts = 0;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt",
+                new AdaptiveCardPromptSettings()
+                {
+                    Card = GetCard(),
+                },
+                (context, cancel) =>
+                {
+                    attempts = int.Parse(context.State["AttemptCount"].ToString());
+                    return Task.FromResult(false);
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => 
+            { 
+                AssertActivityHasCard(activity);
+            })
+            .Send(simulatedInput)
+            .AssertReply((activity) =>
+            {
+                AssertActivityHasCard(activity);
+                Assert.AreEqual(attempts, 1);
+            })
+            .Send(simulatedInput)
+            .AssertReply((activity) =>
+            {
+                AssertActivityHasCard(activity);
+                Assert.AreEqual(attempts, 2);
+            })
+            .Send(simulatedInput)
+            .AssertReply((activity) =>
+            {
+                AssertActivityHasCard(activity);
+                Assert.AreEqual(attempts, 3);
+            })
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task AcceptsCustomValidatorAndCallsItIfRecognizedSucceeded()
+        {
+            var usedValidator = false;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt",
+                new AdaptiveCardPromptSettings()
+                {
+                    Card = GetCard(),
+                },
+                (context, cancel) =>
+                {
+                    Assert.IsTrue(context.Recognized.Succeeded);
+                    usedValidator = true;
+                    return Task.FromResult(true);
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send(simulatedInput)
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task AcceptsCustomValidatorAndCallsItIfNotRecognizedSucceeded()
+        {
+            var usedValidator = false;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt",
+                new AdaptiveCardPromptSettings()
+                {
+                    Card = GetCard(),
+                },
+                (context, cancel) =>
+                {
+                    Assert.IsFalse(context.Recognized.Succeeded);
+                    usedValidator = true;
+                    return Task.FromResult(false);
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send("this is not valid input")
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task DoesNotRepromptIfNotRecognizedSucceededButValidatorTrue()
+        {
+            var usedValidator = false;
+            var prompt = new AdaptiveCardPrompt(
+                "prompt",
+                new AdaptiveCardPromptSettings()
+                {
+                    Card = GetCard(),
+                },
+                (context, cancel) =>
+                {
+                    Assert.IsFalse(context.Recognized.Succeeded);
+                    usedValidator = true;
+                    return Task.FromResult(true);
+                });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("prompt", new PromptOptions());
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = (results.Result as AdaptiveCardPromptResult).Data;
+                    await turnContext.SendActivityAsync("Validator passed");
+                }
+            })
+            .Send("hello")
+            .AssertReply((activity) => { AssertActivityHasCard(activity); })
+            .Send("this is not valid input")
+            .AssertReply("Validator passed")
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        private Attachment GetCard()
+        {
+            var cardPath = Path.Combine("../../../", "adaptiveCard.json");
+            var cardJson = File.ReadAllText(cardPath);
+            var cardAttachment = new Attachment()
+            {
+                ContentType = "application/vnd.microsoft.card.adaptive",
+                Content = JsonConvert.DeserializeObject(cardJson),
+            };
+            return cardAttachment;
+        }
+
+        private List<Attachment> GetAttachmentsWithCard() => new List<Attachment>() { GetCard() };
+
+        private Activity GetSimulatedInput() => new Activity()
+        {
+            Type = ActivityTypes.Message,
+            Value = JObject.FromObject(new
+            {
+                foodChoice = "Steak",
+                steakOther = "some details",
+                steakTemp = "rare",
+                promptId = customPromptId,
+            }),
+        };
+
+        private void AssertActivityHasCard(IActivity activity) => Assert.AreEqual("application/vnd.microsoft.card.adaptive", (activity as Activity).Attachments[0].ContentType);
+    }
+}

--- a/tests/Bot.Builder.Community.Dialogs.Prompts.Tests/adaptiveCard.json
+++ b/tests/Bot.Builder.Community.Dialogs.Prompts.Tests/adaptiveCard.json
@@ -1,0 +1,189 @@
+﻿{
+  "type": "AdaptiveCard",
+  "selectAction": {
+    "type": "Action.Submit",
+    "title": "Test",
+    "data": {
+      "promptId": "custom"
+    }
+  },
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Medium",
+      "weight": "Bolder",
+      "text": "Your registration is almost complete"
+    },
+    {
+      "type": "TextBlock",
+      "text": "What type of food do you prefer?",
+      "wrap": true
+    },
+    {
+      "type": "ImageSet",
+      "images": [
+        {
+          "type": "Image",
+          "url": "http://contososcubademo.azurewebsites.net/assets/steak.jpg",
+          "size": "Medium"
+        },
+        {
+          "type": "Image",
+          "url": "http://contososcubademo.azurewebsites.net/assets/chicken.jpg",
+          "size": "Medium"
+        },
+        {
+          "type": "Image",
+          "url": "http://contososcubademo.azurewebsites.net/assets/tofu.jpg",
+          "size": "Medium"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": "Submit",
+      "data": {
+        "promptId": "custom"
+      }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Steak",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "TextBlock",
+            "size": "Medium",
+            "text": "How would you like your steak prepared?",
+            "wrap": true
+          },
+          {
+            "type": "Input.ChoiceSet",
+            "id": "SteakTemp",
+            "choices": [
+              {
+                "title": "Rare",
+                "value": "rare"
+              },
+              {
+                "title": "Medium-Rare",
+                "value": "medium-rare"
+              },
+              {
+                "title": "Well-done",
+                "value": "well-done"
+              }
+            ],
+            "style": "expanded"
+          },
+          {
+            "type": "Input.Text",
+            "id": "SteakOther",
+            "placeholder": "Any other preparation requests?",
+            "isMultiline": true
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK",
+            "data": {
+              "FoodChoice": "Steak",
+              "promptId": "custom"
+            }
+          }
+        ],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+      }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Chicken",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "TextBlock",
+            "size": "Medium",
+            "text": "Do you have any allergies?",
+            "wrap": true
+          },
+          {
+            "type": "Input.ChoiceSet",
+            "id": "ChickenAllergy",
+            "choices": [
+              {
+                "title": "I'm allergic to peanuts",
+                "value": "peanut"
+              }
+            ],
+            "style": "expanded",
+            "isMultiSelect": true
+          },
+          {
+            "type": "Input.Text",
+            "id": "ChickenOther",
+            "placeholder": "Any other preparation requests?",
+            "isMultiline": true
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK",
+            "data": {
+              "FoodChoice": "Chicken",
+              "promptId": "custom"
+            }
+          }
+        ],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+      }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Tofu",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "TextBlock",
+            "size": "Medium",
+            "text": "Would you like it prepared vegan?",
+            "wrap": true
+          },
+          {
+            "type": "Input.Toggle",
+            "id": "Vegetarian",
+            "title": "Please prepare it vegan",
+            "valueOn": "vegan",
+            "valueOff": "notVegan",
+            "wrap": false
+          },
+          {
+            "type": "Input.Text",
+            "id": "VegOther",
+            "placeholder": "Any other preparation requests?",
+            "isMultiline": true
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK",
+            "data": {
+              "FoodChoice": "Vegetarian",
+              "promptId": "custom"
+            }
+          }
+        ],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+      }
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.0"
+}


### PR DESCRIPTION
It was decided this should go in Community Repo rather than the SDK, but for reference see:

* [Original Dotnet PR](https://github.com/microsoft/botbuilder-dotnet/pull/3003)
* [Original Samples PR](https://github.com/microsoft/BotBuilder-Samples/pull/1986)

Note: There's a couple of classes that are sealed/protected/private in the BF SDK, so I had to copy/paste `PromptValidator` and `PromptValidatorContext` to get this to work.
