### PR TITLE
Convert Alexa attachment types to their strong type if needed.

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
@@ -345,6 +345,8 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core
         /// <param name="response">The SkillResponse to be modified based on the attachments on the Activity object.</param>
         private void ProcessActivityAttachments(Activity activity, SkillResponse response)
         {
+            activity.ConvertAlexaAttachmentContent();
+
             var bfCard = activity.Attachments?.FirstOrDefault(a => a.ContentType == HeroCard.ContentType || a.ContentType == SigninCard.ContentType);
 
             if (bfCard != null)

--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Utility/AttachmentUtility.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Utility/AttachmentUtility.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Alexa.NET.Response;
+using Bot.Builder.Community.Adapters.Alexa.Core.Attachments;
+using Microsoft.Bot.Schema;
+using Microsoft.Rest;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Core.Utility
+{
+    public static class AttachmentUtility
+    {
+        /// <summary>
+        /// Convert all Alexa specific attachments to their correct type.
+        /// </summary>
+        /// <param name="activity"></param>
+        public static void ConvertAlexaAttachmentContent(this Activity activity)
+        {
+            if (activity == null || activity.Attachments == null)
+            {
+                return;
+            }
+
+            foreach (var attachment in activity.Attachments)
+            {
+                if (attachment.ContentType == AlexaAttachmentContentTypes.Card)
+                {
+                    Convert<ICard>(attachment);
+                }
+                else if (attachment.ContentType == AlexaAttachmentContentTypes.Directive)
+                {
+                    Convert<IDirective>(attachment);
+                }
+            }
+        }
+
+        private static void Convert<T>(Attachment attachment)
+        {
+            // Alexa-skills-dotnet has a custom JsonConverter that converts ICards and IDirective to their correct type so we don't need to do that.
+            // However, it throws in two main cases:
+            //  1) [JsonException] When the json fails to deserialize due to various reasons. In this case we want to throw a validation exception to
+            //     let the bot developer know something is wrong.
+            //  2) [Exception] When it doesn't recognize the type. In this case we want to leave the attachment unconverted - we ignore it.
+            //
+            //  See: https://github.com/timheuer/alexa-skills-dotnet/blob/master/Alexa.NET/Response/Converters/CardConverter.cs
+            //       https://github.com/timheuer/alexa-skills-dotnet/blob/master/Alexa.NET/Response/Converters/DirectiveConverter.cs
+            try
+            {
+                attachment.Content = attachment.ContentAs<T>();
+            }
+            catch (JsonException ex)
+            {
+                throw new ValidationException($"Failed to convert Alexa Attachment with ContentType {attachment?.ContentType} to {typeof(T).Name}", ex);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+
+        /// <summary>
+        /// Convert the Attachment Content field to the given type. An exception is thrown if the conversion fails.
+        /// </summary>
+        public static T ContentAs<T>(this Attachment attachment)
+        {
+            if (attachment == null)
+                throw new ArgumentNullException(nameof(attachment));
+
+            if (attachment.Content == null)
+            {
+                return default;
+            }
+            if (typeof(T).IsValueType)
+            {
+                return (T)System.Convert.ChangeType(attachment.Content, typeof(T));
+            }
+            if (attachment.Content is T)
+            {
+                return (T)attachment.Content;
+            }
+            if (typeof(T) == typeof(byte[]))
+            {
+                return (T)(object)System.Convert.FromBase64String(attachment.Content.ToString());
+            }
+            if (attachment.Content is string)
+            {
+                return JsonConvert.DeserializeObject<T>((string)attachment.Content);
+            }
+            return (T)((JObject)attachment.Content).ToObject<T>();
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Utility/AttachmentUtilityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Utility/AttachmentUtilityTests.cs
@@ -1,0 +1,212 @@
+﻿using System.Collections.Generic;
+using Alexa.NET;
+using Alexa.NET.ConnectionTasks.Inputs;
+using Alexa.NET.Response;
+using Alexa.NET.Response.Directive;
+using Alexa.NET.Response.Directive.Templates.Types;
+using Bot.Builder.Community.Adapters.Alexa.Core.Attachments;
+using Bot.Builder.Community.Adapters.Alexa.Core.Utility;
+using Microsoft.Bot.Schema;
+using Microsoft.Rest;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using AlexaCardImage = Alexa.NET.Response.CardImage;
+using AlexaIntent = Alexa.NET.Request.Intent;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests.Utility
+{
+    public class AttachmentUtilityTests
+    {
+        [Fact]
+        public void ConvertNullActivityDoesNothing()
+        {
+            AttachmentUtility.ConvertAlexaAttachmentContent(null);
+        }
+
+        [Fact]
+        public void ConvertNullAttachmentsDoesNothing()
+        {
+            var activity = new Activity
+            {
+                Attachments = null
+            };
+            AttachmentUtility.ConvertAlexaAttachmentContent(activity);
+        }
+
+        [Fact]
+        public void ConvertAttachmentContentTypeNullDoesNothing()
+        {
+            var activity = new Activity
+            {
+                Attachments = new List<Attachment> { new TestAttachment { ContentType = null } }
+            };
+            AttachmentUtility.ConvertAlexaAttachmentContent(activity);
+
+            Assert.Equal(typeof(TestAttachment), activity.Attachments[0].GetType());
+        }
+
+        [Fact]
+        public void ConvertAttachmentAlexaSimpleCard() =>
+            VerifyAttachmentContentConversion<SimpleCard>(new SimpleCard
+            {
+                Content = "Simple card content",
+                Title = "Simle card title"
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentAlexaLinkAccountCard() =>
+            VerifyAttachmentContentConversion<LinkAccountCard>(new LinkAccountCard { }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentAlexaAskForPermissionsConsentCard() =>
+            VerifyAttachmentContentConversion<AskForPermissionsConsentCard>(new AskForPermissionsConsentCard
+            {
+                Permissions = new List<string> { "permission 1", "permission 2" }
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentAlexaStandardCard() =>
+            VerifyAttachmentContentConversion<StandardCard>(new StandardCard
+            {
+                Content = "Standard card content",
+                Title = "Standard card title",
+                Image = new AlexaCardImage { LargeImageUrl = "https://someimagehost/largeimage.png", SmallImageUrl = "https://someimagehost/smallimage.png" }
+            }.ToAttachment());
+
+        [Fact]
+        public void NonSupportedAttachmentCardIsIgnored() =>
+            VerifyAttachmentContentConversion<NonSupportedCard>(new NonSupportedCard
+            {
+                Value = "non-supported card value"
+            }.ToAttachment(), false);
+
+        [Fact]
+        public void ConvertAttachmentAudioPlayerPlayDirective() =>
+            VerifyAttachmentContentConversion<AudioPlayerPlayDirective>(new AudioPlayerPlayDirective
+            {
+                AudioItem = new AudioItem { Stream = new AudioItemStream { Url = "https://streamhost/stream", Token = "123" } },
+                PlayBehavior = PlayBehavior.ReplaceAll
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentClearQueueDirective() =>
+            VerifyAttachmentContentConversion<ClearQueueDirective>(new ClearQueueDirective
+            {
+                ClearBehavior = ClearBehavior.ClearEnqueued
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentDialogConfirmIntent() =>
+            VerifyAttachmentContentConversion<DialogConfirmIntent>(new DialogConfirmIntent
+            {
+                UpdatedIntent = new AlexaIntent { Name = "Intent name", ConfirmationStatus = "success" }
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentDialogConfirmSlot() =>
+            VerifyAttachmentContentConversion<DialogConfirmSlot>(new DialogConfirmSlot("slot name").ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentDialogDelegate() =>
+            VerifyAttachmentContentConversion<DialogDelegate>(new DialogDelegate
+            {
+                UpdatedIntent = new AlexaIntent { Name = "Intent name", ConfirmationStatus = "success" }
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentDialogElicitSlot() =>
+            VerifyAttachmentContentConversion<DialogElicitSlot>(new DialogElicitSlot("slot name")
+            {
+                UpdatedIntent = new AlexaIntent { Name = "Intent name", ConfirmationStatus = "success" }
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentDisplayRenderTemplateDirective() =>
+            VerifyAttachmentContentConversion<DisplayRenderTemplateDirective>(new DisplayRenderTemplateDirective
+            {
+                Template = new BodyTemplate1 { Title = "body template 1" }
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentHintDirective() =>
+            VerifyAttachmentContentConversion<HintDirective>(new HintDirective
+            {
+                Hint = new Hint { Text = "plain text hint" }
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentStopDirective() =>
+            VerifyAttachmentContentConversion<StopDirective>(new StopDirective().ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentVideoAppDirective() =>
+            VerifyAttachmentContentConversion<VideoAppDirective>(new VideoAppDirective
+            {
+                VideoItem = new VideoItem("https://videoitemhost/videoitem")
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentStartConnectionDirective() =>
+            VerifyAttachmentContentConversion<StartConnectionDirective>(new StartConnectionDirective
+            {
+                Token = "123",
+                Uri = "https://somewhere/somewhere",
+                Input = new PrintPdfV1 { Url = "https://somewhere/url" }
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentCompleteTaskDirective() =>
+            VerifyAttachmentContentConversion<CompleteTaskDirective>(new CompleteTaskDirective
+            {
+                Status = new ConnectionStatus { Code = 123, Message = "done" }
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentDialogUpdateDynamicEntities() =>
+            VerifyAttachmentContentConversion<DialogUpdateDynamicEntities>(new DialogUpdateDynamicEntities
+            {
+                Types = new List<SlotType> { new SlotType { Name = "slot name", Values = new [] { new SlotTypeValue { Id = "id" } } } },
+                UpdateBehavior = UpdateBehavior.Replace
+            }.ToAttachment());
+
+        [Fact]
+        public void ConvertAttachmentDirectiveMissingProperties() =>
+            Assert.Throws<ValidationException>(() => VerifyAttachmentContentConversion<StartConnectionDirective>(new StartConnectionDirective
+            {
+                Token = "123",
+                Uri = "https://somewhere/somewhere"
+            }.ToAttachment()));
+
+        private void VerifyAttachmentContentConversion<T>(Attachment attachment, bool supportedType = true)
+        {
+            var activity = new Activity
+            {
+                Attachments = new List<Attachment> { attachment }
+            };
+
+            // Prior to serialization type is as expected.
+            Assert.Equal(typeof(T), activity.Attachments[0].Content.GetType());
+
+            var clonedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+
+            // After conversion the type information is lost.
+            Assert.Equal(typeof(JObject), clonedActivity.Attachments[0].Content.GetType());
+
+            clonedActivity.ConvertAlexaAttachmentContent();
+
+            // After converting Alexa attachments the type information is back.
+            Assert.Equal(supportedType ? typeof(T) : typeof(JObject), clonedActivity.Attachments[0].Content.GetType());
+        }
+
+        class TestAttachment : Attachment
+        {
+        }
+
+        class NonSupportedCard : ICard
+        {
+            string IResponse.Type => nameof(NonSupportedCard);
+            public string Value;
+        }
+    }
+}


### PR DESCRIPTION
Convert the Alexa specific attachment content types to their correct type if needed.

If the type is one that we don't know about we ignore the conversion (leave the type as is) so other layers can take advantage of the attachment. If we are expected to convert the type but it is malformed we throw a ValidationException so the bot developer sees the error.

For most Adapter bots this will do nothing (it is a no-op). For code/bots that get the activity payload via json (ie invoking another bot or other) this will convert it to the right type.