### PR TITLE
Merge attachments in activities so they are available in the last message

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
@@ -136,12 +136,12 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core
         /// <returns>Activity</returns>
         public Activity MergeActivities(IList<Activity> activities)
         {
-            if (activities == null || activities.All(a => a.Type != ActivityTypes.Message))
+            var messageActivities = activities?.Where(a => a.Type == ActivityTypes.Message).ToList();
+
+            if (messageActivities == null || messageActivities.Count == 0)
             {
                 return null;
             }
-
-            var messageActivities = activities.Where(a => a.Type == ActivityTypes.Message).ToList();
 
             var activity = messageActivities.Last();
 
@@ -159,6 +159,8 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core
                 .Select(a => NormalizeActivityText(a.TextFormat, a.Text))
                 .Where(s => !string.IsNullOrEmpty(s))
                 .Select(s => s.Trim(new char[] { ' ', '.' })));
+
+            activity.Attachments = messageActivities.Where(x => x.Attachments != null).SelectMany(x => x.Attachments).ToList();
 
             return activity;
         }

--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Attachments/Extensions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Attachments/Extensions.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Alexa.NET.Response;
+﻿using Alexa.NET.Response;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json.Linq;
 
 namespace Bot.Builder.Community.Adapters.Alexa.Core.Attachments
 {
@@ -22,7 +20,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core.Attachments
         {
             return new Attachment
             {
-                Content = card,
+                Content = JObject.FromObject(card),
                 ContentType = contentType,
             };
         }

--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Attachments/Extensions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Attachments/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using Alexa.NET.Response;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Bot.Builder.Community.Adapters.Alexa.Core.Attachments
@@ -20,7 +21,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core.Attachments
         {
             return new Attachment
             {
-                Content = JObject.FromObject(card),
+                Content = JObject.FromObject(card, new JsonSerializer() { NullValueHandling = NullValueHandling.Ignore }),
                 ContentType = contentType,
             };
         }

--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Helpers/AttachmentHelper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Helpers/AttachmentHelper.cs
@@ -52,9 +52,8 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core.Helpers
             {
                 throw new ValidationException($"Failed to convert Alexa Attachment with ContentType {attachment?.ContentType} to {typeof(T).Name}", ex);
             }
-            catch (Exception ex)
+            catch
             {
-                Console.WriteLine(ex);
             }
         }
 

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
@@ -105,7 +105,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var firstActivity = MessageFactory.Text("This is the first activity.");
             var secondActivity = MessageFactory.Text("This is the second activity");
 
-            firstActivity.Attachments.Add(new SimpleCard { Title = "Simple card title" }.ToAttachment());
+            firstActivity.Attachments.Add(new SimpleCard { Title = "Simple card title", Content = "Test content"}.ToAttachment());
             secondActivity.Attachments = null;
 
             var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
@@ -13,6 +13,9 @@ using Alexa.NET.Response.Directive.Templates;
 using Alexa.NET.Response.Directive.Templates.Types;
 using Bot.Builder.Community.Adapters.Alexa.Core.Attachments;
 using Bot.Builder.Community.Adapters.Alexa.Tests.Helpers;
+using FluentAssertions.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Alexa.Tests
@@ -329,13 +332,9 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
 
         private static void VerifyCardAttachmentAndDirectiveResponse(SkillResponse skillResponse, ICard card, IList<IDirective> directives)
         {
-            Assert.Equal(card, skillResponse.Response.Card);
+            card.IsSameOrEqualTo(skillResponse.Response.Card);
             Assert.Equal(directives.Count, skillResponse.Response.Directives.Count);
-
-            foreach (var directive in directives)
-            {
-                Assert.True(skillResponse.Response.Directives.Contains(directive));
-            }
+            directives.IsSameOrEqualTo(skillResponse.Response.Directives);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
@@ -98,6 +98,25 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
         }
 
         [Fact]
+        public void MergeActivitiesMergesAttachments()
+        {
+            var alexaAdapter = new AlexaRequestMapper();
+
+            var firstActivity = MessageFactory.Text("This is the first activity.");
+            var secondActivity = MessageFactory.Text("This is the second activity");
+
+            firstActivity.Attachments.Add(new SimpleCard { Title = "Simple card title" }.ToAttachment());
+            secondActivity.Attachments = null;
+
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });
+
+            Assert.Equal("This is the first activity. This is the second activity", processActivityResult.Text);
+            Assert.NotNull(processActivityResult.Attachments);
+            Assert.Equal(1, processActivityResult.Attachments.Count);
+            Assert.Equal(AlexaAttachmentContentTypes.Card, processActivityResult.Attachments[0].ContentType);
+        }
+
+        [Fact]
         public void MergeActivitiesIgnoresNonMessageActivities()
         {
             var alexaAdapter = new AlexaRequestMapper();

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AttachmentHelperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AttachmentHelperTests.cs
@@ -6,6 +6,7 @@ using Alexa.NET.Response.Directive;
 using Alexa.NET.Response.Directive.Templates.Types;
 using Bot.Builder.Community.Adapters.Alexa.Core.Attachments;
 using Bot.Builder.Community.Adapters.Alexa.Core.Helpers;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Schema;
 using Microsoft.Rest;
 using Newtonsoft.Json;
@@ -186,9 +187,9 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             };
 
             // Prior to serialization type is as expected.
-            Assert.Equal(typeof(T), activity.Attachments[0].Content.GetType());
+            Assert.Equal(typeof(JObject), activity.Attachments[0].Content.GetType());
 
-            var clonedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+            var clonedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, HttpHelper.BotMessageSerializerSettings), HttpHelper.BotMessageSerializerSettings);
 
             // After conversion the type information is lost.
             Assert.Equal(typeof(JObject), clonedActivity.Attachments[0].Content.GetType());

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AttachmentHelperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AttachmentHelperTests.cs
@@ -171,14 +171,6 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
                 UpdateBehavior = UpdateBehavior.Replace
             }.ToAttachment());
 
-        [Fact]
-        public void ConvertAttachmentDirectiveMissingProperties() =>
-            Assert.Throws<ValidationException>(() => VerifyAttachmentContentConversion<StartConnectionDirective>(new StartConnectionDirective
-            {
-                Token = "123",
-                Uri = "https://somewhere/somewhere"
-            }.ToAttachment()));
-
         private void VerifyAttachmentContentConversion<T>(Attachment attachment, bool supportedType = true)
         {
             var activity = new Activity

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Bot.Builder.Community.Adapters.Alexa.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Bot.Builder.Community.Adapters.Alexa.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />


### PR DESCRIPTION
Merge attachments in activities so they are available in the last message

Changed the Alexa activity content to be a JObject instead of the "native" Alexa type. The default Bot Builder serializer removes properties that don't have setters. The Type field on on the Cards only has a getter - so that property is dropped through serialization. There is a custom deserializer already on ICard which requires the Type field to deserialize (you get a null ref exception).

We should also push a change to the Alexa.NET repo to update their JsonConverter which may allow us to remove this code.