### PR TITLE
Nericson/alexa conversation type

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
@@ -246,7 +246,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core
             activity.ServiceUrl = _options.ServiceUrl ?? $"{alexaSystem.ApiEndpoint}?token={alexaSystem.ApiAccessToken}";
             activity.Recipient = new ChannelAccount(alexaSystem.Application.ApplicationId);
             activity.From = new ChannelAccount(alexaSystem.Person?.PersonId ?? alexaSystem.User.UserId);
-            activity.Conversation = new ConversationAccount(false, "conversation", skillRequest.Session?.SessionId ?? skillRequest.Request.RequestId);
+            activity.Conversation = new ConversationAccount(isGroup: false, id: skillRequest.Session?.SessionId ?? skillRequest.Request.RequestId);
             activity.Timestamp = skillRequest.Request.Timestamp.ToUniversalTime();
             activity.ChannelData = skillRequest;
 

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
@@ -295,7 +295,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             Assert.Equal(mapperOptions.ChannelId, activity.ChannelId);
 
             Assert.NotNull(activity.Conversation);
-            Assert.Equal("conversation", activity.Conversation.ConversationType);
+            Assert.Null(activity.Conversation.ConversationType);
             Assert.Equal(skillRequest.Session.SessionId, activity.Conversation.Id);
             Assert.Equal(false, activity.Conversation.IsGroup);
 


### PR DESCRIPTION
Removed setting the conversation type value for Activities. Per Activity spec:

https://github.com/Microsoft/botframework-sdk/blob/master/specs/botframework-activity/botframework-activity.md

This section:

A2084: Channels SHOULD include the conversation.conversationType field if more than one value is defined for the channel. Channels SHOULD NOT include the field if there is only one possible value.
disable tests in PPE and prod via dial
