### PR TITLE
Convert other attachments to their strong type

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
@@ -347,20 +347,20 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core
         /// <param name="response">The SkillResponse to be modified based on the attachments on the Activity object.</param>
         private void ProcessActivityAttachments(Activity activity, SkillResponse response)
         {
-            activity.ConvertAlexaAttachmentContent();
+            activity.ConvertAttachmentContent();
 
             var bfCard = activity.Attachments?.FirstOrDefault(a => a.ContentType == HeroCard.ContentType || a.ContentType == SigninCard.ContentType);
 
             if (bfCard != null)
             {
-                if (bfCard?.ContentType == SigninCard.ContentType)
+                switch (bfCard.Content)
                 {
-                    response.Response.Card = new LinkAccountCard();
-                }
-
-                if (bfCard?.ContentType == HeroCard.ContentType)
-                {
-                    response.Response.Card = CreateAlexaCardFromHeroCard(bfCard.Content as HeroCard);
+                    case SigninCard signinCard:
+                        response.Response.Card = new LinkAccountCard();
+                        break;
+                    case HeroCard heroCard:
+                        response.Response.Card = CreateAlexaCardFromHeroCard(heroCard);
+                        break;
                 }
             }
             else

--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Helpers/AttachmentHelper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Helpers/AttachmentHelper.cs
@@ -14,7 +14,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core.Helpers
         /// Convert all Alexa specific attachments to their correct type.
         /// </summary>
         /// <param name="activity"></param>
-        public static void ConvertAlexaAttachmentContent(this Activity activity)
+        public static void ConvertAttachmentContent(this Activity activity)
         {
             if (activity == null || activity.Attachments == null)
             {
@@ -23,13 +23,20 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core.Helpers
 
             foreach (var attachment in activity.Attachments)
             {
-                if (attachment.ContentType == AlexaAttachmentContentTypes.Card)
+                switch (attachment.ContentType)
                 {
-                    Convert<ICard>(attachment);
-                }
-                else if (attachment.ContentType == AlexaAttachmentContentTypes.Directive)
-                {
-                    Convert<IDirective>(attachment);
+                    case HeroCard.ContentType:
+                        Convert<HeroCard>(attachment);
+                        break;
+                    case SigninCard.ContentType:
+                        Convert<SigninCard>(attachment);
+                        break;
+                    case AlexaAttachmentContentTypes.Card:
+                        Convert<ICard>(attachment);
+                        break;
+                    case AlexaAttachmentContentTypes.Directive:
+                        Convert<IDirective>(attachment);
+                        break;
                 }
             }
         }

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AttachmentHelperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AttachmentHelperTests.cs
@@ -6,10 +6,8 @@ using Alexa.NET.Response.Directive;
 using Alexa.NET.Response.Directive.Templates.Types;
 using Bot.Builder.Community.Adapters.Alexa.Core.Attachments;
 using Bot.Builder.Community.Adapters.Alexa.Core.Helpers;
-using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Bot.Builder.Community.Adapters.Alexa.Tests.Helpers;
 using Microsoft.Bot.Schema;
-using Microsoft.Rest;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using AlexaCardImage = Alexa.NET.Response.CardImage;
@@ -22,7 +20,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
         [Fact]
         public void ConvertNullActivityDoesNothing()
         {
-            AttachmentHelper.ConvertAlexaAttachmentContent(null);
+            AttachmentHelper.ConvertAttachmentContent(null);
         }
 
         [Fact]
@@ -32,7 +30,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             {
                 Attachments = null
             };
-            activity.ConvertAlexaAttachmentContent();
+            activity.ConvertAttachmentContent();
         }
 
         [Fact]
@@ -42,7 +40,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             {
                 Attachments = new List<Attachment> { new TestAttachment { ContentType = null } }
             };
-            activity.ConvertAlexaAttachmentContent();
+            activity.ConvertAttachmentContent();
 
             Assert.Equal(typeof(TestAttachment), activity.Attachments[0].GetType());
         }
@@ -181,15 +179,15 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             // Prior to serialization type is as expected.
             Assert.Equal(typeof(JObject), activity.Attachments[0].Content.GetType());
 
-            var clonedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, HttpHelper.BotMessageSerializerSettings), HttpHelper.BotMessageSerializerSettings);
+            var anonymizedActivity = ActivityHelper.GetAnonymizedActivity(activity);
 
             // After conversion the type information is lost.
-            Assert.Equal(typeof(JObject), clonedActivity.Attachments[0].Content.GetType());
+            Assert.Equal(typeof(JObject), anonymizedActivity.Attachments[0].Content.GetType());
 
-            clonedActivity.ConvertAlexaAttachmentContent();
+            anonymizedActivity.ConvertAttachmentContent();
 
             // After converting Alexa attachments the type information is back.
-            Assert.Equal(supportedType ? typeof(T) : typeof(JObject), clonedActivity.Attachments[0].Content.GetType());
+            Assert.Equal(supportedType ? typeof(T) : typeof(JObject), anonymizedActivity.Attachments[0].Content.GetType());
         }
 
         class TestAttachment : Attachment

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Helpers/ActivityHelper.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Helpers/ActivityHelper.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests.Helpers
+{
+    public static class ActivityHelper
+    {
+        /// <summary>
+        /// Anonymize the activity by removing type information from properties that don't include type information (ie are passed as objects).
+        /// </summary>
+        public static Activity GetAnonymizedActivity(Activity activity) => JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, HttpHelper.BotMessageSerializerSettings), HttpHelper.BotMessageSerializerSettings);
+    }
+}


### PR DESCRIPTION
Convert the Bot Framework attachment types to their strong type.

The type information for these gets lost when it, for example, goes through serialization. Added code to convert them to their strong type and some unit tests for validation.