### PR TITLE
Change Alexa md renderer to remove trailing periods. Added more tests.

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Helpers/AlexaMarkdownToPlaintextRenderer.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Helpers/AlexaMarkdownToPlaintextRenderer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.MarkedNet;
+﻿using Microsoft.MarkedNet;
 
 namespace Bot.Builder.Community.Adapters.Alexa.Core.Helpers
 {
@@ -43,11 +42,14 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core.Helpers
                 return $"{body.Trim().TrimEnd(',')}. ";
             }
             public override string ListItem(string text) => $"{ListItemMarker}{text}, ";
-            public override string Paragraph(string text) => string.Concat(text.TrimEnd('.'), ". ");
+            public override string Paragraph(string text) => string.Concat(text.Replace("\n", " ").TrimEnd('.'), ". ");
             public override string Strong(string text) => text;
             public override string Table(string header, string body) => string.Empty;
             public override string TableCell(string content, TableCellFlags flags) => string.Empty;
             public override string TableRow(string content) => string.Empty;
+            public override string Text(string text) => text.TrimEnd('.');
+            public override string Preprocess(string text) => text.Trim();
+            public override string Postprocess(string text) => text.Trim();
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaMarkdownToPlaintextRendererTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaMarkdownToPlaintextRendererTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Bot.Builder.Community.Adapters.Alexa.Core.Helpers;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests
+{
+    public class AlexaMarkdownToPlaintextRendererTests
+    {
+        [Fact]
+        public void ConvertTextWithTrailingPeriod()
+        {
+            var md = "Text text.";
+            var result = AlexaMarkdownToPlaintextRenderer.Render(md);
+            Assert.Equal(md, result);
+        }
+
+        [Fact]
+        public void ConvertTextWithNoTrailingPeriod()
+        {
+            var md = "Text text";
+            var result = AlexaMarkdownToPlaintextRenderer.Render(md);
+            // Trailing period is added because it is a paragraph. Alexa TTS doesn't mind either way.
+            Assert.Equal("Text text.", result);
+        }
+
+        [Fact]
+        public void ConvertTextLeadingTrailingWhitespace()
+        {
+            var md = "         Text text            ";
+            var result = AlexaMarkdownToPlaintextRenderer.Render(md);
+            Assert.Equal("Text text.", result);
+        }
+
+        [Fact]
+        public void ConvertTextTrailingNewline()
+        {
+            var md = "Text text\n";
+            var result = AlexaMarkdownToPlaintextRenderer.Render(md);
+            Assert.Equal("Text text.", result);
+        }
+
+        [Fact]
+        public void ConvertTextNoTrailingNewline()
+        {
+            var md = "Text text";
+            var result = AlexaMarkdownToPlaintextRenderer.Render(md);
+            Assert.Equal("Text text.", result);
+        }
+
+        [Fact]
+        public void ConvertTextBrAndParagraphs()
+        {
+            var md = "Same line.\nSame line.  \n2nd line.\n\r3rd line.";
+            var result = AlexaMarkdownToPlaintextRenderer.Render(md);
+            Assert.Equal("Same line. Same line. 2nd line. 3rd line.", result);
+        }
+
+        [Fact]
+        public void ConvertTextBrAndParagraphsNoSpacesBetween()
+        {
+            var md = "Same line.\nSame line.\n2nd line.\n\r3rd line.";
+            var result = AlexaMarkdownToPlaintextRenderer.Render(md);
+            Assert.Equal("Same line. Same line. 2nd line. 3rd line.", result);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaMarkdownToPlaintextRendererTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaMarkdownToPlaintextRendererTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Bot.Builder.Community.Adapters.Alexa.Core.Helpers;
+﻿using Bot.Builder.Community.Adapters.Alexa.Core.Helpers;
 using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Alexa.Tests
@@ -63,6 +60,14 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var md = "Same line.\nSame line.\n2nd line.\n\r3rd line.";
             var result = AlexaMarkdownToPlaintextRenderer.Render(md);
             Assert.Equal("Same line. Same line. 2nd line. 3rd line.", result);
+        }
+
+        [Fact]
+        public void ConvertQuotesAndUrls()
+        {
+            var md = "{   \"contentType\": \"image/jpeg\",   \"content\": \"https://somefantasticurl/\",   \"name\": \"Attachment1.jpg\" }";
+            var result = AlexaMarkdownToPlaintextRenderer.Render(md);
+            Assert.Equal("{   \"contentType\": \"image/jpeg\",   \"content\": \"https://somefantasticurl/\",   \"name\": \"Attachment1.jpg\" }.", result);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
@@ -1,21 +1,21 @@
+using System.Collections.Generic;
+using System.Text;
 using Alexa.NET.Request;
 using Alexa.NET.Request.Type;
 using Alexa.NET.Response;
-using Bot.Builder.Community.Adapters.Alexa.Core;
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Logging;
-using Moq;
-using System.Collections.Generic;
-using System.Text;
 using Alexa.NET.Response.Directive;
 using Alexa.NET.Response.Directive.Templates;
 using Alexa.NET.Response.Directive.Templates.Types;
+using Bot.Builder.Community.Adapters.Alexa.Core;
 using Bot.Builder.Community.Adapters.Alexa.Core.Attachments;
 using Bot.Builder.Community.Adapters.Alexa.Tests.Helpers;
 using FluentAssertions.Common;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Alexa.Tests
@@ -98,6 +98,25 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });
 
             Assert.Equal("This is the first activity. This is the second activity", processActivityResult.Text);
+        }
+
+        [Fact]
+        public void MergeActivitiesAttachmentAndPlainText()
+        {
+            var alexaAdapter = new AlexaRequestMapper();
+
+            var attachment = new Attachment
+            {
+                Name = "Attachment1.jpg",
+                ContentType = "image/jpeg",
+                Content = "https://somefantasticurl/",
+            };
+            var firstActivity = MessageFactory.Text(JsonConvert.SerializeObject(attachment, HttpHelper.BotMessageSerializerSettings));
+            var secondActivity = (Activity) MessageFactory.Attachment(attachment);
+
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { firstActivity, secondActivity });
+
+            Assert.Equal("{   \"contentType\": \"image/jpeg\",   \"content\": \"https://somefantasticurl/\",   \"name\": \"Attachment1.jpg\" }", processActivityResult.Text);
         }
 
         [Fact]


### PR DESCRIPTION
This string 
  "Same line.\nSame line.  \n2nd line.\n\r3rd line."
was being converted to 
  "Same line.\nSame line.. 2nd line. 3rd line"
The \n in the middle should have been stripped out and the double .. before 2nd line should be removed.

This fixes it so it returns
  "Same line. Same line. 2nd line. 3rd line."
and adds some tests.

Also quotes and links were not being rendered right. Quotes would be converted to &quot; and links would get repeated. Fixed and added tests.