### PR TITLE
Updated Suggested Actions conversion logic 

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa/Bot.Builder.Community.Adapters.Alexa.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa/Bot.Builder.Community.Adapters.Alexa.csproj
@@ -27,8 +27,4 @@
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Bot.Builder.Community.Adapters.Alexa.Core\Bot.Builder.Community.Adapters.Alexa.Core.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/libraries/Bot.Builder.Community.Adapters.Alexa/Bot.Builder.Community.Adapters.Alexa.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa/Bot.Builder.Community.Adapters.Alexa.csproj
@@ -27,4 +27,8 @@
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Bot.Builder.Community.Adapters.Alexa.Core\Bot.Builder.Community.Adapters.Alexa.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/libraries/Bot.Builder.Community.Adapters.Google.Core/ConversationRequestMapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Google.Core/ConversationRequestMapper.cs
@@ -160,7 +160,8 @@ namespace Bot.Builder.Community.Adapters.Google.Core
                             }
                         }
                     };
-                    response.ExpectedInputs.First().InputPrompt.RichInitialPrompt.Suggestions = ConvertSuggestedActionsToSuggestionChips(activity)?.ToArray();
+                    response.ExpectedInputs.First().InputPrompt.RichInitialPrompt.Suggestions = ConvertIMAndMessageBackSuggestedActionsToSuggestionChips(activity)?.ToArray();
+                    response.ExpectedInputs.First().InputPrompt.RichInitialPrompt.LinkOutSuggestion = GetLinkOutSuggestionFromActivity(activity);
                     break;
             }
 

--- a/libraries/Bot.Builder.Community.Adapters.Google.Core/DialogFlowRequestMapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Google.Core/DialogFlowRequestMapper.cs
@@ -125,7 +125,8 @@ namespace Bot.Builder.Community.Adapters.Google.Core
 
             response.Payload.Google.RichResponse = new RichResponse()
             {
-                Items = responseItems.ToArray()
+                Items = responseItems.ToArray(),
+                LinkOutSuggestion = GetLinkOutSuggestionFromActivity(activity)
             };
 
             // ensure InputHint is set as required for response
@@ -144,7 +145,7 @@ namespace Bot.Builder.Community.Adapters.Google.Core
                 case InputHints.ExpectingInput:
                     response.Payload.Google.ExpectUserResponse = true;
 
-                    var suggestionChips = ConvertSuggestedActionsToSuggestionChips(activity);
+                    var suggestionChips = ConvertIMAndMessageBackSuggestedActionsToSuggestionChips(activity);
                     if (suggestionChips.Any())
                     {
                         response.Payload.Google.RichResponse.Suggestions = suggestionChips.ToArray();

--- a/libraries/Bot.Builder.Community.Adapters.Google.Core/GoogleRequestMapperBase.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Google.Core/GoogleRequestMapperBase.cs
@@ -202,7 +202,7 @@ namespace Bot.Builder.Community.Adapters.Google.Core
             return query;
         }
 
-        public static List<Suggestion> ConvertSuggestedActionsToSuggestionChips(Activity activity)
+        public static List<Suggestion> ConvertIMAndMessageBackSuggestedActionsToSuggestionChips(Activity activity)
         {
             var suggestions = new List<Suggestion>();
 
@@ -210,11 +210,34 @@ namespace Bot.Builder.Community.Adapters.Google.Core
             {
                 foreach (var suggestion in activity.SuggestedActions.Actions)
                 {
-                    suggestions.Add(new Suggestion { Title = suggestion.Title });
+                    if (suggestion.Type == ActionTypes.ImBack || suggestion.Type == ActionTypes.MessageBack)
+                    {
+                        suggestions.Add(new Suggestion { Title = suggestion.Title });
+                    }
                 }
             }
 
             return suggestions;
+        }
+
+        public static LinkOutSuggestion GetLinkOutSuggestionFromActivity(Activity activity)
+        {
+            var openUrlSuggestedAction = activity.SuggestedActions?.Actions?.Where(a => a.Type == ActionTypes.OpenUrl).FirstOrDefault();
+
+            if(openUrlSuggestedAction == null)
+            {
+                return null;
+            }
+
+            return new LinkOutSuggestion()
+            {
+                DestinationName = openUrlSuggestedAction.Title,
+                OpenUrlAction = new OpenUrlAction()
+                {
+                    Url = openUrlSuggestedAction.Value?.ToString(),
+                    UrlTypeHint = UrlTypeHint.URL_TYPE_HINT_UNSPECIFIED
+                }
+            };
         }
     }
 }

--- a/samples/Google Adapter Sample/Bots/EchoBot.cs
+++ b/samples/Google Adapter Sample/Bots/EchoBot.cs
@@ -38,6 +38,17 @@ namespace Bot.Builder.Community.Samples.Google.Bots
                     await turnContext.SendActivityAsync(activityWithSigninCard, cancellationToken);
                     break;
 
+                case "chips":
+                    var activityWithChips = MessageFactory.Text($"Ok, I included some suggested actions.");
+                    activityWithChips.SuggestedActions = new SuggestedActions(actions: new List<CardAction>
+                    {
+                        new CardAction { Title = "Yes", Type= ActionTypes.ImBack, Value = "Y" },
+                        new CardAction { Title = "No", Type= ActionTypes.ImBack, Value = "N" },
+                        new CardAction { Title = "Click to learn more", Type= ActionTypes.OpenUrl, Value = "http://www.progressive.com" }
+                    });
+                    await turnContext.SendActivityAsync(activityWithChips, cancellationToken);
+                    break;
+
                 case "list":
                     var activityWithListAttachment = MessageFactory.Text($"Ok, I included a list.");
                     var listIntent = GoogleHelperIntentFactory.CreateListIntent(
@@ -123,7 +134,7 @@ namespace Bot.Builder.Community.Samples.Google.Bots
                         },
                         "Table Card Title",
                         "Table card subtitle",
-                        new List<Button>() { new Button() { Title = "Click here", OpenUrlAction = new OpenUrlAction() { Url = "https://www.microsoft.com" }}  });
+                        new List<Button>() { new Button() { Title = "Click here", OpenUrlAction = new OpenUrlAction() { Url = "https://www.microsoft.com" } } });
                     activityWithTableCardAttachment.Attachments.Add(tableCard.ToAttachment());
                     await turnContext.SendActivityAsync(activityWithTableCardAttachment, cancellationToken);
                     break;

--- a/samples/Google Adapter Sample/Google Adapter Sample.csproj
+++ b/samples/Google Adapter Sample/Google Adapter Sample.csproj
@@ -6,14 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bot.Builder.Community.Adapters.Google" Version="4.6.4-beta0033" />
+    <PackageReference Include="Bot.Builder.Community.Adapters.Google" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\libraries\Bot.Builder.Community.Adapters.Google.Core\Bot.Builder.Community.Adapters.Google.Core.csproj" />
-    <ProjectReference Include="..\..\libraries\Bot.Builder.Community.Adapters.Google\Bot.Builder.Community.Adapters.Google.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updated logic for SuggestedActions to only convert IMBack and MesageBack CardActions into suggestion chips (as we can only use the text value and those action types map logically to suggestion chips).
- Added logic to look for a SuggestedAction with an action type of OpenUrl and if one exists, use the value to set the LinkOutSuggestion on the Google response.
- Remove unnecessary project referencefrom the Alexa project.