### PR TITLE
Update NuGet packages for libs and samples

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Bot.Builder.Community.Adapters.Alexa.Core.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Bot.Builder.Community.Adapters.Alexa.Core.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Alexa.NET" Version="1.13.3" />
     <PackageReference Include="Alexa.NET.CustomerProfile" Version="2.1.1" />
     <PackageReference Include="Microsoft.MarkedNet" Version="1.0.13" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.9.2" />
   </ItemGroup>
 
 </Project>

--- a/libraries/Bot.Builder.Community.Adapters.Alexa/Bot.Builder.Community.Adapters.Alexa.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa/Bot.Builder.Community.Adapters.Alexa.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.1" />
   </ItemGroup>
 

--- a/libraries/Bot.Builder.Community.Adapters.Google.Core/Bot.Builder.Community.Adapters.Google.Core.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Google.Core/Bot.Builder.Community.Adapters.Google.Core.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="JWT" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.MarkedNet" Version="1.0.13" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />

--- a/libraries/Bot.Builder.Community.Adapters.Google/Bot.Builder.Community.Adapters.Google.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Google/Bot.Builder.Community.Adapters.Google.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="JWT" Version="5.0.1" />
-		<PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-		<PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+		<PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+		<PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
 		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.1" />

--- a/libraries/Bot.Builder.Community.Adapters.Infobip/Bot.Builder.Community.Adapters.Infobip.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Infobip/Bot.Builder.Community.Adapters.Infobip.csproj
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
   </ItemGroup>
 
 </Project>

--- a/libraries/Bot.Builder.Community.Adapters.RingCentral/Bot.Builder.Community.Adapters.RingCentral.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.RingCentral/Bot.Builder.Community.Adapters.RingCentral.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Bot.Builder.Community.Adapters.Twitter.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Bot.Builder.Community.Adapters.Twitter.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
   </ItemGroup>

--- a/libraries/Bot.Builder.Community.Adapters.Zoom/Bot.Builder.Community.Adapters.Zoom.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Zoom/Bot.Builder.Community.Adapters.Zoom.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.1" />
     <PackageReference Include="RestSharp" Version="106.10.2-alpha.0.8" />
   </ItemGroup>

--- a/libraries/Bot.Builder.Community.Dialogs.Adaptive.Rest/Bot.Builder.Community.Dialogs.Adaptive.Rest.csproj
+++ b/libraries/Bot.Builder.Community.Dialogs.Adaptive.Rest/Bot.Builder.Community.Dialogs.Adaptive.Rest.csproj
@@ -17,7 +17,7 @@
     <Folder Include="Actions\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.8.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.9.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
   </ItemGroup>
 </Project>

--- a/libraries/Bot.Builder.Community.Dialogs.Adaptive.Rest/RestComponentRegistration.cs
+++ b/libraries/Bot.Builder.Community.Dialogs.Adaptive.Rest/RestComponentRegistration.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Newtonsoft.Json;
@@ -8,12 +10,12 @@ namespace Bot.Builder.Community.Dialogs.Adaptive.Rest
 {
     public class RestComponentRegistration : ComponentRegistration, IComponentDeclarativeTypes
     {
-        public IEnumerable<JsonConverter> GetConverters(ResourceExplorer resourceExplorer, Stack<string> paths)
+        public IEnumerable<JsonConverter> GetConverters(ResourceExplorer resourceExplorer, SourceContext sourceContext)
         {
             return new JsonConverter[] { };
         }
 
-        public IEnumerable<DeclarativeType> GetDeclarativeTypes()
+        public IEnumerable<DeclarativeType> GetDeclarativeTypes(ResourceExplorer resourceExplorer)
         {
             return new DeclarativeType[] { };
         }

--- a/libraries/Bot.Builder.Community.Dialogs.ChoiceFlow/Bot.Builder.Community.Dialogs.ChoiceFlow.csproj
+++ b/libraries/Bot.Builder.Community.Dialogs.ChoiceFlow/Bot.Builder.Community.Dialogs.ChoiceFlow.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/libraries/Bot.Builder.Community.Dialogs.DataTypeDisambiguation/Bot.Builder.Community.Dialogs.DataTypeDisambiguation.csproj
+++ b/libraries/Bot.Builder.Community.Dialogs.DataTypeDisambiguation/Bot.Builder.Community.Dialogs.DataTypeDisambiguation.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.2" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
   </ItemGroup>
 

--- a/libraries/Bot.Builder.Community.Dialogs.FormFlow/Bot.Builder.Community.Dialogs.FormFlow.csproj
+++ b/libraries/Bot.Builder.Community.Dialogs.FormFlow/Bot.Builder.Community.Dialogs.FormFlow.csproj
@@ -40,8 +40,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.2" />
     <PackageReference Include="Microsoft.Recognizers.Text" Version="1.3.2" />
 		<PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.3.2" />
 		<PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />

--- a/libraries/Bot.Builder.Community.Dialogs.Location/Bot.Builder.Community.Dialogs.Location.csproj
+++ b/libraries/Bot.Builder.Community.Dialogs.Location/Bot.Builder.Community.Dialogs.Location.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="CoreCompat.System.Drawing" Version="1.0.0-beta006" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/libraries/Bot.Builder.Community.Dialogs.Luis/Bot.Builder.Community.Dialogs.Luis.csproj
+++ b/libraries/Bot.Builder.Community.Dialogs.Luis/Bot.Builder.Community.Dialogs.Luis.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.2" />
   </ItemGroup>
 
 </Project>

--- a/libraries/Bot.Builder.Community.Dialogs.Prompts/Bot.Builder.Community.Dialogs.Prompts.csproj
+++ b/libraries/Bot.Builder.Community.Dialogs.Prompts/Bot.Builder.Community.Dialogs.Prompts.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.2" />
   </ItemGroup>
 
 </Project>

--- a/libraries/Bot.Builder.Community.Middleware.AzureAdAuthentication/Bot.Builder.Community.Middleware.AzureAdAuthentication.csproj
+++ b/libraries/Bot.Builder.Community.Middleware.AzureAdAuthentication/Bot.Builder.Community.Middleware.AzureAdAuthentication.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
   </ItemGroup>

--- a/libraries/Bot.Builder.Community.Middleware.BestMatch/Bot.Builder.Community.Middleware.BestMatch.csproj
+++ b/libraries/Bot.Builder.Community.Middleware.BestMatch/Bot.Builder.Community.Middleware.BestMatch.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
   </ItemGroup>
 
 </Project>

--- a/libraries/Bot.Builder.Community.Middleware.HandleActivityType/Bot.Builder.Community.Middleware.HandleActivityType.csproj
+++ b/libraries/Bot.Builder.Community.Middleware.HandleActivityType/Bot.Builder.Community.Middleware.HandleActivityType.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
   </ItemGroup>
 
 </Project>

--- a/libraries/Bot.Builder.Community.Middleware.SentimentAnalysis/Bot.Builder.Community.Middleware.SentimentAnalysis.csproj
+++ b/libraries/Bot.Builder.Community.Middleware.SentimentAnalysis/Bot.Builder.Community.Middleware.SentimentAnalysis.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language.TextAnalytics" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.0" />
     <PackageReference Include="SentimentAnalyzer" Version="1.1.0" />

--- a/libraries/Bot.Builder.Community.Middleware.SpellCheck/Bot.Builder.Community.Middleware.SpellCheck.csproj
+++ b/libraries/Bot.Builder.Community.Middleware.SpellCheck/Bot.Builder.Community.Middleware.SpellCheck.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language.SpellCheck" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
   </ItemGroup>

--- a/libraries/Bot.Builder.Community.Recognizers.FuzzyRecognizer/Bot.Builder.Community.Recognizers.FuzzyRecognizer.csproj
+++ b/libraries/Bot.Builder.Community.Recognizers.FuzzyRecognizer/Bot.Builder.Community.Recognizers.FuzzyRecognizer.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
   </ItemGroup>
 
 </Project>

--- a/libraries/Bot.Builder.Community.Storage.Elasticsearch/Bot.Builder.Community.Storage.Elasticsearch.csproj
+++ b/libraries/Bot.Builder.Community.Storage.Elasticsearch/Bot.Builder.Community.Storage.Elasticsearch.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
     <PackageReference Include="NEST" Version="7.6.1" />
     <PackageReference Include="NEST.JsonNetSerializer" Version="7.6.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/libraries/Bot.Builder.Community.Storage.EntityFramework/Bot.Builder.Community.Storage.EntityFramework.csproj
+++ b/libraries/Bot.Builder.Community.Storage.EntityFramework/Bot.Builder.Community.Storage.EntityFramework.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/samples/Alexa Adapter Sample/Alexa Adapter Sample.csproj
+++ b/samples/Alexa Adapter Sample/Alexa Adapter Sample.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bot.Builder.Community.Adapters.Alexa" Version="4.8.2-beta0111" />
-    <PackageReference Include="Bot.Builder.Community.Adapters.Alexa.Core" Version="4.8.2-beta0111" />
+    <PackageReference Include="Bot.Builder.Community.Adapters.Alexa" Version="4.8.7" />
+    <PackageReference Include="Bot.Builder.Community.Adapters.Alexa.Core" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/BestMatch Middleware Sample/BestMatch Middleware Sample.csproj
+++ b/samples/BestMatch Middleware Sample/BestMatch Middleware Sample.csproj
@@ -22,15 +22,15 @@
    </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bot.Builder.Community.Middleware.BestMatch" Version="4.8.2" />
+    <PackageReference Include="Bot.Builder.Community.Middleware.BestMatch" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/ChoiceFlow Dialog Sample/ChoiceFlow Dialog Sample.csproj
+++ b/samples/ChoiceFlow Dialog Sample/ChoiceFlow Dialog Sample.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bot.Builder.Community.Dialogs.ChoiceFlow" Version="4.8.2" />
+    <PackageReference Include="Bot.Builder.Community.Dialogs.ChoiceFlow" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/samples/Cortana Assistant Alexa Sample/Cortana Assistant Alexa Sample.csproj
+++ b/samples/Cortana Assistant Alexa Sample/Cortana Assistant Alexa Sample.csproj
@@ -11,15 +11,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bot.Builder.Community.Adapters.Alexa" Version="4.8.2" />
-    <PackageReference Include="Bot.Builder.Community.Adapters.Google" Version="4.8.2" />
+    <PackageReference Include="Bot.Builder.Community.Adapters.Alexa" Version="4.8.7" />
+    <PackageReference Include="Bot.Builder.Community.Adapters.Google" Version="4.8.7" />
     <PackageReference Include="HtmlAgilityPack" Version="1.9.2" />
     <PackageReference Include="Microsoft.AspNetCore.All" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/samples/Form Flow Sample/Form Flow Sample.csproj
+++ b/samples/Form Flow Sample/Form Flow Sample.csproj
@@ -11,12 +11,12 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.3" />
-    <PackageReference Include="Bot.Builder.Community.Dialogs.FormFlow" Version="4.8.2" />
+    <PackageReference Include="Bot.Builder.Community.Dialogs.FormFlow" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Google Adapter Sample/Google Adapter Sample.csproj
+++ b/samples/Google Adapter Sample/Google Adapter Sample.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Bot.Builder.Community.Adapters.Google" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Infobip Adapter Sample/Infobip Adapter Sample.csproj
+++ b/samples/Infobip Adapter Sample/Infobip Adapter Sample.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Bot.Builder.Community.Adapters.Infobip" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
   </ItemGroup>
 
     <ItemGroup>

--- a/samples/Location Dialog Sample/Location Dialog Sample.csproj
+++ b/samples/Location Dialog Sample/Location Dialog Sample.csproj
@@ -17,15 +17,15 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Bot.Builder.Community.Dialogs.Location" Version="4.8.2" />
+    <PackageReference Include="Bot.Builder.Community.Dialogs.Location" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.1" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/Luis Dialog Sample/Luis Dialog Sample.csproj
+++ b/samples/Luis Dialog Sample/Luis Dialog Sample.csproj
@@ -17,10 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bot.Builder.Community.Dialogs.Luis" Version="4.8.2" />
+    <PackageReference Include="Bot.Builder.Community.Dialogs.Luis" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/RingCentral Adapter Sample/RingCentral Adapter Sample.csproj
+++ b/samples/RingCentral Adapter Sample/RingCentral Adapter Sample.csproj
@@ -15,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bot.Builder.Community.Adapters.RingCentral" Version="4.8.2" />
+    <PackageReference Include="Bot.Builder.Community.Adapters.RingCentral" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.9.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.9" />
   </ItemGroup>
 

--- a/samples/Sentiment Middleware Sample/Sentiment Middleware Sample.csproj
+++ b/samples/Sentiment Middleware Sample/Sentiment Middleware Sample.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bot.Builder.Community.Middleware.SentimentAnalysis" Version="4.8.5" />
+    <PackageReference Include="Bot.Builder.Community.Middleware.SentimentAnalysis" Version="4.8.7" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />

--- a/samples/Twitter Adapter Sample/Twitter Adapter Sample.csproj
+++ b/samples/Twitter Adapter Sample/Twitter Adapter Sample.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Bot.Builder.Community.Twitter.Adapter" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
   </ItemGroup>
 

--- a/samples/Zoom Adapter Sample/Zoom Adapter Sample.csproj
+++ b/samples/Zoom Adapter Sample/Zoom Adapter Sample.csproj
@@ -7,12 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bot.Builder.Community.Adapters.Zoom" Version="4.8.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\libraries\Bot.Builder.Community.Adapters.Zoom\Bot.Builder.Community.Adapters.Zoom.csproj" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Bot.Builder.Community.Adapters.Alexa.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Bot.Builder.Community.Adapters.Alexa.Tests.csproj
@@ -13,7 +13,10 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Bot.Builder.Community.Adapters.RingCentral.Tests/Bot.Builder.Community.Adapters.RingCentral.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.RingCentral.Tests/Bot.Builder.Community.Adapters.RingCentral.Tests.csproj
@@ -41,7 +41,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.2.0">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests/Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests.csproj
+++ b/tests/Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests/Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests.csproj
@@ -10,8 +10,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.8.0-rc0" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.9.2-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests/Fakes/FakeEchoRestAction.cs
+++ b/tests/Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests/Fakes/FakeEchoRestAction.cs
@@ -46,12 +46,10 @@ namespace Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests.Fakes
                 RequestUri = new Uri(url),
             };
 
-            var dcState = dc.GetState();
-
             // Set content
             if (Content != null)
             {
-                this._httpRequest.Content = new StringContent(this.Content.GetValue(dcState));
+                this._httpRequest.Content = new StringContent(this.Content.GetValue(dc.State));
             }
 
             // Set Headers
@@ -65,7 +63,7 @@ namespace Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests.Fakes
 
             if (this.ResultProperty != null)
             {
-                dcState.SetValue(this.ResultProperty.GetValue(dcState), result);
+                dc.State.SetValue(this.ResultProperty.GetValue(dc.State), result);
             }
 
             // return the actionResult as the result of this operation

--- a/tests/Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests/Startup.cs
+++ b/tests/Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests/Startup.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.AI.Luis;
+using Microsoft.Bot.Builder.Dialogs.Adaptive;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
+using Microsoft.Bot.Builder.Dialogs.Declarative;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bot.Builder.Community.Dialogs.Adaptive.Rest.Tests
+{
+    [TestClass]
+    public class Startup
+    {
+        [AssemblyInitialize]
+        public static void Initialize(TestContext testContext)
+        {
+            ComponentRegistration.Add(new DeclarativeComponentRegistration());
+            ComponentRegistration.Add(new AdaptiveComponentRegistration());
+            ComponentRegistration.Add(new AdaptiveTestingComponentRegistration());
+            ComponentRegistration.Add(new LuisComponentRegistration());
+            ComponentRegistration.Add(new LanguageGenerationComponentRegistration());
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Middleware.Tests/Bot.Builder.Community.Middleware.Tests.csproj
+++ b/tests/Bot.Builder.Community.Middleware.Tests/Bot.Builder.Community.Middleware.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/tests/Bot.Builder.Community.Recognizers.Tests/Bot.Builder.Community.Recognizers.Tests.csproj
+++ b/tests/Bot.Builder.Community.Recognizers.Tests/Bot.Builder.Community.Recognizers.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/tests/Bot.Builder.Community.Storage.Tests/Bot.Builder.Community.Storage.Tests.csproj
+++ b/tests/Bot.Builder.Community.Storage.Tests/Bot.Builder.Community.Storage.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />


### PR DESCRIPTION
- Updates lib SDK dependencies to 4.9
- Update samples to use 4.8 Bot Builder Community packages
- Fix breaking state change in adaptive (due to GA in 4.9)