### PR TITLE
map locale for all alexa requests

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs
@@ -185,7 +185,6 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core
             var activity = Activity.CreateMessageActivity() as Activity;
             activity = SetGeneralActivityProperties(activity, skillRequest);
             activity.Text = intentRequest.Intent.Slots[_options.DefaultIntentSlotName].Value;
-            activity.Locale = intentRequest.Locale;
             return activity;
         }
 
@@ -249,6 +248,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Core
             activity.Conversation = new ConversationAccount(isGroup: false, id: skillRequest.Session?.SessionId ?? skillRequest.Request.RequestId);
             activity.Timestamp = skillRequest.Request.Timestamp.ToUniversalTime();
             activity.ChannelData = skillRequest;
+            activity.Locale = skillRequest.Request.Locale;
 
             return activity;
         }

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
@@ -55,6 +55,127 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
         }
 
         [Fact]
+        public void IntentRequestMappedReturnsLocale()
+        {
+            // arrange
+            var skillRequest = new SkillRequest
+            {
+                Request = new IntentRequest()
+                {
+                    Locale = "en-US",
+                    Intent = new Intent()
+                    {
+                        Slots = new Dictionary<string, Slot>()
+                        {
+                            { "phrase", new Slot() }
+                        }
+                    }
+                },
+                Context = new Context
+                {
+                    System = new AlexaSystem() { Application = new Application(), User = new User() }
+                },
+                Session = new Session()
+                {
+                    User = new User()
+                }
+            };
+
+
+            // act
+            var alexaMapper = new AlexaRequestMapper();
+            var result = alexaMapper.RequestToActivity(skillRequest);
+
+            // assert
+            Assert.Equal("en-US", result.Locale);
+        }
+
+        [Fact]
+        public void LaunchRequestMappedReturnsNull()
+        {
+            // arrange
+            var skillRequest = new SkillRequest
+            {
+                Request = new LaunchRequest() {},
+                Context = new Context
+                {
+                    System = new AlexaSystem() { Application = new Application(), User = new User() }
+                },
+                Session = new Session()
+                {
+                    User = new User()
+                }
+            };
+
+
+            // act
+            var alexaMapper = new AlexaRequestMapper();
+            var result = alexaMapper.RequestToActivity(skillRequest);
+
+            // assert
+            Assert.Null(result.Locale);
+        }
+
+        [Fact]
+        public void IntentRequestMappedReturnsNull()
+        {
+            // arrange
+            var skillRequest = new SkillRequest
+            {
+                Request = new IntentRequest() { Intent = new Intent() 
+                    { 
+                        Slots = new Dictionary<string, Slot>()
+                        {
+                            { "phrase", new Slot() }
+                        }
+                    }
+                },
+                Context = new Context
+                {
+                    System = new AlexaSystem() { Application = new Application(), User = new User() }
+                },
+                Session = new Session()
+                {
+                    User = new User()
+                }
+            };
+
+
+            // act
+            var alexaMapper = new AlexaRequestMapper();
+            var result = alexaMapper.RequestToActivity(skillRequest);
+
+            // assert
+            Assert.Null(result.Locale);
+        }
+
+        [Fact]
+        public void LaunchRequestMappedReturnsLocale()
+        {
+            // arrange
+            var skillRequest = new SkillRequest
+            {
+                Request = new LaunchRequest() {Locale = "en-US"},
+                Context = new Context
+                {
+                    System = new AlexaSystem() {Application = new Application(), User = new User()}
+                },
+                Session = new Session()
+                {
+                    User = new User()
+                }
+            };
+
+
+            // act
+            var alexaMapper = new AlexaRequestMapper();
+            var result = alexaMapper.RequestToActivity(skillRequest);
+
+            // assert
+            Assert.Equal("en-US", result.Locale);
+        }
+
+        [Fact]
         public void MergeActivitiesReturnIdenticalSingleActivityNoSsml()
         {
             const string text = "This is the single activity";


### PR DESCRIPTION
#### Background

There is a minor issue with the Alexa adapter mapping the skill request's locale through only for message activities (and not for other activity types e.g. conversation updates) - detailed in issue https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/issues/277

This fix is a small change to always map the `skillRequest.Request.Locale`. If there is a value, we get it.

#### Testing this PR

Run the unit tests and ensure that all complete successfully. This PR adds four new unit tests:

![image](https://user-images.githubusercontent.com/6830648/85758458-41378380-b708-11ea-9524-6e51ebee095a.png)
