### PR TITLE
add device to google request schema

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Google.Core/Model/Request/ConversationWebhookRequestSchema.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Google.Core/Model/Request/ConversationWebhookRequestSchema.cs
@@ -10,8 +10,14 @@ namespace Bot.Builder.Community.Adapters.Google.Core.Model.Request
         public Surface Surface { get; set; }
         public Input[] Inputs { get; set; }
         public User User { get; set; }
+        public Device Device { get; set; }
         public Conversation Conversation { get; set; }
         public AvailableSurface[] AvailableSurfaces { get; set; }
+    }
+
+    public class Device
+    {
+        public Location Location { get; set; }
     }
 
     public class Surface


### PR DESCRIPTION
#### Background

This PR adds the `Device` object to `ConversationRequest` required to support Google location services (`DEVICE_PRECISE_LOCATION` permission).

https://developers.google.com/assistant/conversational/df-asdk/reference/webhook/rest/Shared.Types/AppRequest#Device
https://developers.google.com/assistant/conversational/df-asdk/helpers

#### Testing this PR

1. Create a basic bot connected to a Google Action (**Important note:** that this will not work on Family Friendly Actions as it uses PII so disable that in Google Actions console) and send a permission request to Google e.g.:

```
var reply = turnContext.Activity.CreateReply();
var systemIntentAttachment = new PermissionsIntent()
{
    InputValueData = new PermissionsInputValueData()
    {
        Type = "type.googleapis.com/google.actions.v2.PermissionValueSpec",
        OptContext = "To give you a personal experience",
        Permissions = new List<Bot.Builder.Community.Adapters.Google.Core.Model.SystemIntents.Permission>(new[] { (Bot.Builder.Community.Adapters.Google.Core.Model.SystemIntents.Permission)3 })
    }
};
var attachment = new Attachment(GoogleAttachmentContentTypes.PermissionsIntent, content: systemIntentAttachment);
reply.Attachments.Add(attachment);
await turnContext.SendActivityAsync(reply);
```

2. On the callback from Google, inspect the activity channel data and verify that the `Device` is populated with the location details accordingly.

![image](https://user-images.githubusercontent.com/6830648/85882659-968e9600-b7d7-11ea-8546-43d4057f4202.png)
