### PR TITLE
add google hero card mapping

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Google.Core/GoogleRequestMapperBase.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Google.Core/GoogleRequestMapperBase.cs
@@ -182,6 +182,20 @@ namespace Bot.Builder.Community.Adapters.Google.Core
 
             activity.ConvertAttachmentContent();
 
+            var heroCardAttachment = activity.Attachments?.FirstOrDefault(att => att.ContentType == "application/vnd.microsoft.card.hero");
+            if (heroCardAttachment?.Content is HeroCard heroCard)
+            {
+                var imageUrl = heroCard.Images?.FirstOrDefault()?.Url;
+                var buttons = new List<Button>();
+                if (heroCard.Buttons != null)
+                {
+                    buttons.AddRange(heroCard.Buttons.Select(heroCardButton => new Button() {Title = heroCardButton.Title, OpenUrlAction = new OpenUrlAction() {Url = heroCardButton.Value?.ToString()}}));
+                }
+
+                var basicCard = GoogleCardFactory.CreateBasicCard(heroCard.Title, heroCard.Subtitle, heroCard.Text, buttons, imageUrl != null ? new Image { Url = imageUrl } : null);
+                responseItems.Add(basicCard);
+            }
+            
             var basicCardItem = ProcessResponseItemAttachment<BasicCard>(GoogleAttachmentContentTypes.BasicCard, activity);
             if (basicCardItem != null)
                 responseItems.Add(basicCardItem);

--- a/libraries/Bot.Builder.Community.Adapters.Google.Core/GoogleRequestMapperBase.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Google.Core/GoogleRequestMapperBase.cs
@@ -182,35 +182,35 @@ namespace Bot.Builder.Community.Adapters.Google.Core
 
             activity.ConvertAttachmentContent();
 
-            var heroCardAttachment = activity.Attachments?.FirstOrDefault(att => att.ContentType == "application/vnd.microsoft.card.hero");
-            if (heroCardAttachment?.Content is HeroCard heroCard)
+            var bfCard = activity.Attachments?.FirstOrDefault(a => a.ContentType == HeroCard.ContentType);
+
+            if (bfCard != null)
             {
-                var imageUrl = heroCard.Images?.FirstOrDefault()?.Url;
-                var buttons = new List<Button>();
-                if (heroCard.Buttons != null)
+                switch (bfCard.Content)
                 {
-                    buttons.AddRange(heroCard.Buttons.Select(heroCardButton => new Button() {Title = heroCardButton.Title, OpenUrlAction = new OpenUrlAction() {Url = heroCardButton.Value?.ToString()}}));
+                    case HeroCard heroCard:
+                        responseItems.Add(CreateGoogleCardFromHeroCard(heroCard));
+                        break;
                 }
-
-                var basicCard = GoogleCardFactory.CreateBasicCard(heroCard.Title, heroCard.Subtitle, heroCard.Text, buttons, imageUrl != null ? new Image { Url = imageUrl } : null);
-                responseItems.Add(basicCard);
             }
-            
-            var basicCardItem = ProcessResponseItemAttachment<BasicCard>(GoogleAttachmentContentTypes.BasicCard, activity);
-            if (basicCardItem != null)
-                responseItems.Add(basicCardItem);
+            else
+            {
+                var basicCardItem = ProcessResponseItemAttachment<BasicCard>(GoogleAttachmentContentTypes.BasicCard, activity);
+                if (basicCardItem != null)
+                    responseItems.Add(basicCardItem);
 
-            var tableCardItem = ProcessResponseItemAttachment<TableCard>(GoogleAttachmentContentTypes.TableCard, activity);
-            if (tableCardItem != null)
-                responseItems.Add(tableCardItem);
+                var tableCardItem = ProcessResponseItemAttachment<TableCard>(GoogleAttachmentContentTypes.TableCard, activity);
+                if (tableCardItem != null)
+                    responseItems.Add(tableCardItem);
 
-            var mediaItem = ProcessResponseItemAttachment<MediaResponse>(GoogleAttachmentContentTypes.MediaResponse, activity);
-            if (mediaItem != null)
-                responseItems.Add(mediaItem);
+                var mediaItem = ProcessResponseItemAttachment<MediaResponse>(GoogleAttachmentContentTypes.MediaResponse, activity);
+                if (mediaItem != null)
+                    responseItems.Add(mediaItem);
 
-            var browsingCarousel = ProcessResponseItemAttachment<BrowsingCarousel>(GoogleAttachmentContentTypes.BrowsingCarousel, activity);
-            if (browsingCarousel != null)
-                responseItems.Add(browsingCarousel);
+                var browsingCarousel = ProcessResponseItemAttachment<BrowsingCarousel>(GoogleAttachmentContentTypes.BrowsingCarousel, activity);
+                if (browsingCarousel != null)
+                    responseItems.Add(browsingCarousel);
+            }
 
             return responseItems;
         }
@@ -268,6 +268,22 @@ namespace Bot.Builder.Community.Adapters.Google.Core
                     UrlTypeHint = UrlTypeHint.URL_TYPE_HINT_UNSPECIFIED
                 }
             };
+        }
+
+        private BasicCard CreateGoogleCardFromHeroCard(HeroCard heroCard)
+        {
+            var imageUrl = heroCard.Images?.FirstOrDefault()?.Url;
+            var buttons = new List<Button>();
+            if (heroCard.Buttons != null)
+            {
+                buttons.AddRange(heroCard.Buttons.Select(heroCardButton => new Button()
+                {
+                    Title = heroCardButton.Title,
+                    OpenUrlAction = new OpenUrlAction() { Url = heroCardButton.Value?.ToString() }
+                }));
+            }
+
+            return GoogleCardFactory.CreateBasicCard(heroCard.Title, heroCard.Subtitle, heroCard.Text,  buttons, imageUrl != null ? new Image { Url = imageUrl } : null);
         }
     }
 }


### PR DESCRIPTION
#### Background

This adds support for mapping a bot framework hero card to google basic card

#### Testing this PR

The code is pretty small and I have added conditions to deal with constraints that Google places on the basic card, namely:
- The basic card can only have [one button attached](https://actions-on-google.github.io/actions-on-google-nodejs/classes/conversation_response.basiccard.html#buttons)
- The button, if present must be an [`openUrl` and have a http or https URL](https://actions-on-google.github.io/actions-on-google-nodejs/interfaces/actionssdk_api_v2.googleactionsv2uielementsopenurlaction.html#url)
- The image, if present [should have accessible text](https://actions-on-google.github.io/actions-on-google-nodejs/interfaces/actionssdk_api_v2.googleactionsv2uielementsimage.html#accessibilitytext), if it is not available then default to the hero card title

I used a hero card defined in `.lg` to test this (the `ActivityTemplate` below), and is here for reference:

```
# ActionTemplate(msg)
[CardAction
    Type = openUrl
    Title = ${msg}
    Value = https://www.google.com
    Text = ${msg}
]

# HeroCardTemplate
[HeroCard
    title = BotFramework Hero Card
    subtitle = Microsoft Bot Framework
    text = Build and connect intelligent bots to interact with your users naturally wherever they are, from text/sms to Skype, Slack, Office 365 mail and other popular services.
    speak = Build and connect intelligent bots to interact with your users naturally wherever they are, from text/sms to Skype, Slack, Office 365 mail and other popular services.
    image = https://sec.ch9.ms/ch9/7ff5/e07cfef0-aa3b-40bb-9baa-7c9ef8ff7ff5/buildreactionbotframework_960.jpg
    buttons = ${ActionTemplate('Play a game')} | ${ActionTemplate('What is the time')} | ${ActionTemplate('How is the weather')}
]

# ActivityTemplate
[Activity
    Speak = hello world
    Attachments = ${HeroCardTemplate()}
    InputHint = ignoringInput
]
```

![Screenshot_20200708-234717](https://user-images.githubusercontent.com/6830648/86978100-f0974000-c175-11ea-9428-194439d33683.png)

