### PR TITLE
Updated MessageBird C# SDK to version 3

### DIFF
--- a/Bot.Builder.Community.Samples.sln
+++ b/Bot.Builder.Community.Samples.sln
@@ -30,6 +30,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Teams Zoom Sample", "sample
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFramework Storage Sample", "samples\EntityFramework Storage Sample\EntityFramework Storage Sample.csproj", "{0EB315B8-7E1E-4F03-ABF1-C258A08640BE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageBird Adapter Sample", "samples\MessageBird Adapter Sample\MessageBird Adapter Sample.csproj", "{B3B1BC29-2C54-49A4-A739-1C23D2CE13D5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -92,6 +94,10 @@ Global
 		{0EB315B8-7E1E-4F03-ABF1-C258A08640BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0EB315B8-7E1E-4F03-ABF1-C258A08640BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0EB315B8-7E1E-4F03-ABF1-C258A08640BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3B1BC29-2C54-49A4-A739-1C23D2CE13D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3B1BC29-2C54-49A4-A739-1C23D2CE13D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3B1BC29-2C54-49A4-A739-1C23D2CE13D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3B1BC29-2C54-49A4-A739-1C23D2CE13D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/Bot.Builder.Community.Adapters.MessageBird.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/Bot.Builder.Community.Adapters.MessageBird.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessageBird" Version="2.1.0" />
+    <PackageReference Include="MessageBird" Version="3.0.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.10.0" />
   </ItemGroup>
 

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapter.cs
@@ -40,14 +40,8 @@ namespace Bot.Builder.Community.Adapters.MessageBird
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _logger = logger ?? NullLogger.Instance;
 
-            if (_options.UseWhatsAppSandbox)
-            {
-                _messageBirdClient = Client.CreateDefault(_options.AccessKey, features: new Client.Features[] { Client.Features.EnableWhatsAppSandboxConversations });
-            }
-            else
-            {
-                _messageBirdClient = Client.CreateDefault(_options.AccessKey);
-            }
+            _messageBirdClient = Client.CreateDefault(_options.AccessKey);
+
             _requestAuthorization = new MessageBirdRequestAuthorization();
         }
         Client _messageBirdClient;

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapterOptions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapterOptions.cs
@@ -8,17 +8,15 @@ namespace Bot.Builder.Community.Adapters.MessageBird
     public class MessageBirdAdapterOptions
     {
         public MessageBirdAdapterOptions(IConfiguration configuration)
-            : this(configuration["MessageBirdAccessKey"], configuration["MessageBirdSigningKey"], Convert.ToBoolean(configuration["MessageBirdUseWhatsAppSandbox"]))
+            : this(configuration["MessageBirdAccessKey"], configuration["MessageBirdSigningKey"])
         { }
 
-        public MessageBirdAdapterOptions(string accessKey, string signingKey, bool useWhatsAppSandbox)
+        public MessageBirdAdapterOptions(string accessKey, string signingKey)
         {
             AccessKey = accessKey;
             SigningKey = signingKey;
-            UseWhatsAppSandbox = useWhatsAppSandbox;
         }
         public string AccessKey { get; set; }
         public string SigningKey { get; set; }
-        public bool UseWhatsAppSandbox { get; set; }
     }
 }

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
@@ -50,8 +50,7 @@ You could create in the project an `appsettings.json` file to set the MessageBir
 ```json
 {
   "MessageBirdAccessKey": "",
-  "MessageBirdSigningKey": "",
-  "MessageBirdUseWhatsAppSandbox": true
+  "MessageBirdSigningKey": ""
 }
 ```
 

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
@@ -101,7 +101,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                     {
                         ContentType = contentType,
                         ContentUrl = response.message.content.Image.Url,
-                        Name = ""// response.message.content.image.caption
+                        Name = response.message.content.Image.Caption
                     }
                 };
             }

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
@@ -49,7 +49,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                 var contentType = attachment.ContentType.ToLower();
                 if (contentType.Contains("image"))
                 {
-                    message.conversationMessageRequest.Content = new Content() { Image = new MediaContent() { Url = attachment.ContentUrl } };
+                    message.conversationMessageRequest.Content = new Content() { Image = new MediaContent() { Url = attachment.ContentUrl, Caption = attachment.Name } };
                     message.conversationMessageRequest.Type = ContentType.Image;
                 }
                 else if (contentType.Contains("video"))

--- a/samples/MessageBird Adapter Sample/MessageBird Adapter Sample.csproj
+++ b/samples/MessageBird Adapter Sample/MessageBird Adapter Sample.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Bot.Builder.Community.Adapters.MessageBird" Version="4.9.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.10.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.0" />
   </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
MessageBird C# SDK is updated, I reflected the change to this adapter.
Changes
- UseWhatsAppSandbox parameter is no longer required. I removed the parameter, also updated readme file.
- I added MessageBird Adapter Sample project to sample solution file.
- Image caption is now supported. When bot sends an image attachment with name, name property will be send as image caption to WhatsApp. This was missing, now completed.

After this PR is merged and new nuget is released, i'll also update the sample project with new nuget link of this adapter. 