### PR TITLE
Update the [Configure your Actions SDK project] Section

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.ActionsSDK/README.md
+++ b/libraries/Bot.Builder.Community.Adapters.ActionsSDK/README.md
@@ -75,11 +75,14 @@ This article will walk you through modifying the EchoBot sample to connect it to
 
 ![Select action template](/libraries/Bot.Builder.Community.Adapters.ActionsSDK/media/actions-sdk-project-created.PNG?raw=true)
 
-### Configure your Actions SDK project
+### Setup and Configure your Actions SDK project
 
 You now need to configure your new Actions SDK project, with appropriate settings, scenes, intents, types etc. You will do this using the gactions CLI tool and the provided action template files included in the 'action' folder in this repository.
 
-1. If you haven't already, [install the gactions CLI tool](https://developers.google.com/assistant/conversational/quickstart#install_the_gactions_command-line_tool).
+1. If you haven't already, 
+    * [Install the gactions CLI tool](https://developers.google.com/assistant/conversational/quickstart#install_the_gactions_command-line_tool).
+
+    * [Get the hello world sample](https://developers.google.com/assistant/conversational/quickstart#get_the_hello_world_sample).
 
 2. Navigate to action/settings/settings.yaml, and replace <YOUR PROJECT ID> with your project ID. You can find your project id by navigating to **Project settings** from the menu in the top right hand of the Google Actions Console.
 


### PR DESCRIPTION
The Actions SDK Project needs to be Created and Configured on Google (covered in the [Create Actions SDK Project] section) as well as be initialized locally using the gactions CLI. Unfortunately the current instructions only state you need to install the CLI then "Navigate to action/settings/settings.yaml".
However "Navigate to action/settings/settings.yaml" doesn't exist unless you also follow the instructions in [Get the hello world sample]. 
This changes adds the missing step