### PR TITLE
New LG components for manually evaluating an LG template

### DIFF
--- a/Bot.Builder.Community.sln
+++ b/Bot.Builder.Community.sln
@@ -148,9 +148,12 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bot.Builder.Community.Components.Dialogs.Input", "libraries\Bot.Builder.Community.Components.Dialogs.Input\Bot.Builder.Community.Components.Dialogs.Input.csproj", "{4999E3C2-0281-411E-9A5E-660832A5ABE7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bot.Builder.Community.Components.TokenExchangeSkillHandler", "libraries\Bot.Builder.Community.Components.TokenExchangeSkillHandler\Bot.Builder.Community.Components.TokenExchangeSkillHandler.csproj", "{97B74354-8D6B-482B-A779-2E20B38DF0DD}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bot.Builder.Community.Components.Handoff.ServiceNow", "libraries\Bot.Builder.Community.Components.Handoff.ServiceNow\Bot.Builder.Community.Components.Handoff.ServiceNow.csproj", "{63A62728-74B0-4BA3-9ACA-87E583BBB9B4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bot.Builder.Community.Components.TokenExchangeSkillHandler.Tests", "tests\Bot.Builder.Community.Components.TokenExchangeSkillHandler.Tests\Bot.Builder.Community.Components.TokenExchangeSkillHandler.Tests.csproj", "{0EDBC769-26A4-4556-9D58-DF5416745187}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bot.Builder.Community.Components.LanguageGeneration", "libraries\Bot.Builder.Community.Components.LanguageGeneration\Bot.Builder.Community.Components.LanguageGeneration.csproj", "{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -638,14 +641,6 @@ Global
 		{97B74354-8D6B-482B-A779-2E20B38DF0DD}.Documentation|Any CPU.Build.0 = Debug|Any CPU
 		{97B74354-8D6B-482B-A779-2E20B38DF0DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97B74354-8D6B-482B-A779-2E20B38DF0DD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0EDBC769-26A4-4556-9D58-DF5416745187}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
-		{0EDBC769-26A4-4556-9D58-DF5416745187}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
-		{0EDBC769-26A4-4556-9D58-DF5416745187}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0EDBC769-26A4-4556-9D58-DF5416745187}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0EDBC769-26A4-4556-9D58-DF5416745187}.Documentation|Any CPU.ActiveCfg = Debug|Any CPU
-		{0EDBC769-26A4-4556-9D58-DF5416745187}.Documentation|Any CPU.Build.0 = Debug|Any CPU
-		{0EDBC769-26A4-4556-9D58-DF5416745187}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0EDBC769-26A4-4556-9D58-DF5416745187}.Release|Any CPU.Build.0 = Release|Any CPU
 		{63A62728-74B0-4BA3-9ACA-87E583BBB9B4}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
 		{63A62728-74B0-4BA3-9ACA-87E583BBB9B4}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
 		{63A62728-74B0-4BA3-9ACA-87E583BBB9B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -654,6 +649,22 @@ Global
 		{63A62728-74B0-4BA3-9ACA-87E583BBB9B4}.Documentation|Any CPU.Build.0 = Debug|Any CPU
 		{63A62728-74B0-4BA3-9ACA-87E583BBB9B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63A62728-74B0-4BA3-9ACA-87E583BBB9B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0EDBC769-26A4-4556-9D58-DF5416745187}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EDBC769-26A4-4556-9D58-DF5416745187}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{0EDBC769-26A4-4556-9D58-DF5416745187}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EDBC769-26A4-4556-9D58-DF5416745187}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EDBC769-26A4-4556-9D58-DF5416745187}.Documentation|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EDBC769-26A4-4556-9D58-DF5416745187}.Documentation|Any CPU.Build.0 = Debug|Any CPU
+		{0EDBC769-26A4-4556-9D58-DF5416745187}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EDBC769-26A4-4556-9D58-DF5416745187}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4}.Documentation|Any CPU.ActiveCfg = Debug|Any CPU
+		{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4}.Documentation|Any CPU.Build.0 = Debug|Any CPU
+		{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -727,6 +738,7 @@ Global
 		{97B74354-8D6B-482B-A779-2E20B38DF0DD} = {1F7F4CAF-CF22-491F-840D-A63835726C12}
 		{63A62728-74B0-4BA3-9ACA-87E583BBB9B4} = {1F7F4CAF-CF22-491F-840D-A63835726C12}
 		{0EDBC769-26A4-4556-9D58-DF5416745187} = {840D4038-9AB8-4750-9FFE-365386CE47E2}
+		{40D170FA-AC4D-43B6-AB2A-ACCF1B5EE0F4} = {1F7F4CAF-CF22-491F-840D-A63835726C12}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9FE3B75E-BA2B-45BC-BBF0-DDA8BA10C4F0}

--- a/libraries/Bot.Builder.Community.Components.LanguageGeneration/Bot.Builder.Community.Components.LanguageGeneration.csproj
+++ b/libraries/Bot.Builder.Community.Components.LanguageGeneration/Bot.Builder.Community.Components.LanguageGeneration.csproj
@@ -1,0 +1,53 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildThisFileDirectory)../', 'Bot.Builder.Community.sln'))\CommonTargets\library.shared.targets" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>Composer actions for working more directly with the bots Language Generation (LG) system.</Description>
+    <Authors>Bot Builder Community</Authors>
+    <Company>Bot Builder Community</Company>
+    <PackageLicenseUrl>https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/master/libraries/Bot.Builder.Community.Components.LanguageGeneration</PackageProjectUrl>
+    <Version>1.0.4-preview</Version>
+    <PackageIcon>package-icon.png</PackageIcon>
+    <RepositoryUrl>https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/</RepositoryUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <PackageTags>bots;ai;botframework;botbuilder;msbot-component;msbot-action</PackageTags>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bot.Builder" Version="$(Bot_Builder_Version)" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="$(Bot_Builder_Version)" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="$(Bot_Builder_Version)" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="$(Bot_Builder_Version)" />
+    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="$(Bot_Builder_Version)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="**/*.dialog" />
+    <Content Include="**/*.lg" />
+    <Content Include="**/*.lu" />
+    <Content Include="**/*.schema" />
+    <Content Include="**/*.uischema" />
+    <Content Include="**/*.qna" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Schemas\BotBuilderCommunity.EvaluateLGTemplate.schema" />
+    <None Remove="Schemas\BotBuilderCommunity.EvaluateLGTemplate.uischema" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="..\..\package-icon.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/libraries/Bot.Builder.Community.Components.LanguageGeneration/EvaluateLGTemplate.cs
+++ b/libraries/Bot.Builder.Community.Components.LanguageGeneration/EvaluateLGTemplate.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Components.LanguageGeneration
+{
+    public class EvaluateLGTemplate : Dialog
+    {
+        [JsonConstructor]
+        public EvaluateLGTemplate([CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
+            : base()
+        {
+            // enable instances of this command as debug break point
+            this.RegisterSourceLocation(sourceFilePath, sourceLineNumber);
+        }
+
+        [JsonProperty("$kind")]
+        public const string Kind = "BotBuilderCommunity.EvaluateLGTemplate";
+
+        [JsonProperty("disabled")]
+        public BoolExpression Disabled { get; set; }
+
+        [JsonProperty("property")]
+        public StringExpression Property { get; set; }
+
+        [JsonProperty("template")]
+        public string Template { get; set; }
+
+        public async override Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (options is CancellationToken)
+            {
+                throw new ArgumentException($"{nameof(options)} cannot be a cancellation token");
+            }
+
+            if (this.Disabled != null && this.Disabled.GetValue(dc.State) == true)
+            {
+                return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            // Get property name
+            var property = Property?.GetValue(dc.State);
+            if (String.IsNullOrEmpty(property))
+            {
+                throw new Exception($"{this.Id}: property name not specified.");
+            }
+
+            // Get LG template
+            if (String.IsNullOrEmpty(Template))
+            {
+                throw new Exception($"{this.Id}: LG template not specified.");
+            }
+
+            // Evaluate template
+            var languageGenerator = dc.Services.Get<LanguageGenerator>() ?? throw new MissingMemberException(nameof(LanguageGeneration));
+            var lgResult = await languageGenerator.GenerateAsync(dc, Template, dc.State).ConfigureAwait(false);
+
+            // Copy result to property
+            dc.State.SetValue(property, lgResult);
+
+            return await dc.EndDialogAsync(lgResult, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override string OnComputeId()
+        {
+            return $"{GetType().Name}[{Template?.ToString()}]";
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Components.LanguageGeneration/LanguageGenerationBotComponent.cs
+++ b/libraries/Bot.Builder.Community.Components.LanguageGeneration/LanguageGenerationBotComponent.cs
@@ -1,0 +1,19 @@
+﻿using AdaptiveExpressions.Converters;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs.Declarative;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bot.Builder.Community.Components.LanguageGeneration
+{
+    /// <summary>
+    /// <see cref="BotComponent"/> implementation for the storage actions.
+    /// </summary>
+    public class LanguageGenerationBotComponent : BotComponent
+    {
+        public override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddSingleton<DeclarativeType>(new DeclarativeType<EvaluateLGTemplate>(EvaluateLGTemplate.Kind));
+        }
+    }
+}

--- a/libraries/Bot.Builder.Community.Components.LanguageGeneration/LanguageGenerationComponentRegistration.cs
+++ b/libraries/Bot.Builder.Community.Components.LanguageGeneration/LanguageGenerationComponentRegistration.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Bot.Builder.Dialogs.Declarative.Obsolete;
+
+namespace Bot.Builder.Community.Components.LanguageGeneration
+{
+    /// <summary>
+    /// <see cref="LanguageGenerationComponentRegistration"/> implementation for adaptive components.
+    /// </summary>
+    public class LanguageGenerationComponentRegistration : DeclarativeComponentRegistrationBridge<LanguageGenerationBotComponent>
+    {
+    }
+}

--- a/libraries/Bot.Builder.Community.Components.LanguageGeneration/Schemas/BotBuilderCommunity.EvaluateLGTemplate.schema
+++ b/libraries/Bot.Builder.Community.Components.LanguageGeneration/Schemas/BotBuilderCommunity.EvaluateLGTemplate.schema
@@ -1,0 +1,38 @@
+﻿{
+  "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+  "$role": "implements(Microsoft.IDialog)",
+  "title": "Evaluate Template",
+  "description": "Evaluates an LG template and saves its result to a memory variable.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "title": "Id",
+      "description": "Optional id for the dialog"
+    },
+    "disabled": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Disabled",
+      "description": "Optional condition which if true will disable this action.",
+      "examples": [
+        "user.age > 3"
+      ]
+    },
+    "property": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Property",
+      "description": "Property (named location to store template results)."
+    },
+    "template": {
+      "type": "string",
+      "title": "Template",
+      "description": "LG Template to evaluate.",
+      "examples": [
+        "${WelcomeUser()}",
+        "Hello ${user.name}",
+        "https://example.com/search?q=${turn.activity.text}"
+      ]
+    }
+  },
+  "required": [ "property", "template" ]
+}

--- a/libraries/Bot.Builder.Community.Components.LanguageGeneration/Schemas/BotBuilderCommunity.EvaluateLGTemplate.uischema
+++ b/libraries/Bot.Builder.Community.Components.LanguageGeneration/Schemas/BotBuilderCommunity.EvaluateLGTemplate.uischema
@@ -1,0 +1,27 @@
+﻿{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "form": {
+    "label": "Evaluate an LG Template",
+    "subtitle": "Evaluate LG Template",
+    "order": [
+      "property",
+      "template",
+      "*"
+    ],
+    "properties": {
+      "property": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      }
+    }
+  },
+  "menu": {
+    "label": "Evaluate an LG Template",
+    "submenu": [ "Language Generation" ]
+  },
+  "flow": {
+    "widget": "ActionCard",
+    "body": "${coalesce(action.property, \"?\")} : ${coalesce(action.template, \"?\")}"
+  }
+}


### PR DESCRIPTION
This adds a new `Bot.Builder.Community.Components.LanguageGeneration` package which adds new action(s) for working directly with LG.  It initially contains a single `EvaluateLGTemplate` action for calling an LG template within the context of a dialog and saving the results to memory versus sending them as a response.  I have some ideas for more actions which will be added later.

I've tested it but still need to write the docs which I'll add shortly via another PR.