### PR TITLE
Checking for the takeControl flag.

### DIFF
--- a/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/Models/ServiceNowResponseMessage.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/Models/ServiceNowResponseMessage.cs
@@ -9,5 +9,6 @@
         public Body[] body { get; set; }
         public bool completed { get; set; }
         public float score { get; set; }
+        public bool takeControl { get; set; }
     }
 }

--- a/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
@@ -53,7 +53,7 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                         await HandleContentEvent(responseMessage);
 
                         // If ServiceNow indicates it's completed handoff from it's perspective we end handoff and return control.
-                        if (responseMessage.completed)
+                        if (responseMessage.completed || responseMessage.takeControl)
                         {
                             var eventActivity = EventFactory.CreateHandoffStatus(handoffRecord.ConversationReference.Conversation, "completed") as Activity;
                             await (_adapter).ContinueConversationAsync(


### PR DESCRIPTION
**Type:** Issue
**Description:**  If the user is idle for X hours when he is in SN VA context, SN VA gives a message as "Left conversation", but doesn't hand off back to MS Bot.

**Solution/Fix:** A flag called takeControl is given after an idle time period. Along with the response completed flag, have to check this condition to take the control back to MS Bot.  