### PR TITLE
Limiting the buttons and cards

### DIFF
--- a/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
@@ -91,6 +91,7 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
         // Bot owners specific requirements and styling.
         private async Task HandleContentEvent(ServiceNowResponseMessage responseMessage)
         {
+            int VAOptionsCount = 0;
             foreach (var item in responseMessage.body)
             {
                 IMessageActivity responseActivity;
@@ -127,7 +128,13 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                             List<CardAction> cardActions = new List<CardAction>();
                             foreach (var option in item.options)
                             {
-                                cardActions.Add(new CardAction("imBack", option.description ?? option.label, value: option.label));
+                                 VAOptionsCount = VAOptionsCount + 1;
+                                 cardActions.Add(new CardAction("imBack", option.description ?? option.label, value: option.label));
+                                   if (VAOptionsCount <= item.options.Count())
+                                    {
+                                    if (VAOptionsCount == 50)
+                                    break;
+                                    }
                             }
 
                             var pickerHeroCard = new HeroCard(buttons: cardActions);
@@ -143,8 +150,14 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                         // Map the picker concept to a basic HeroCard with buttons
                         List<CardAction> defaultPickerActions = new List<CardAction>();
                         foreach (var option in item.options)
-                        {
+                        {                            
+                            VAOptionsCount = VAOptionsCount + 1;
                             defaultPickerActions.Add(new CardAction("imBack", option.description ?? option.label, value: option.label));
+                            if (VAOptionsCount <= item.options.Count())
+                            {
+                            if (VAOptionsCount == 50)
+                            break;
+                            }
                         }
 
                         var defaultPickerCard = new HeroCard(buttons: defaultPickerActions);
@@ -159,7 +172,12 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                         {
                             var card = new HeroCard(subtitle: action.description, buttons: new List<CardAction>
                                 {new CardAction("openUrl", action.label ?? action.action, value: action.action)});
-                            responseActivity.Attachments.Add(card.ToAttachment());
+                               if (VAOptionsCount <= item.values.Count())
+                               {
+                                    if (VAOptionsCount == 11)
+                                    break;
+                                    responseActivity.Attachments.Add(card.ToAttachment());
+                               }
                         }
                         break;
                     case "OutputHtml":


### PR DESCRIPTION
**Type:** Improvement
**Description:** Carousel can show max of 50 buttons and 10 cards in the hero card. However, there are chances to thrown an exception/bad user experience in different devices. 
**Solution/Fix:** Limiting the number of buttons to 50  and cards to 10 that can be rendered in a Hero card carousel to handle the exceptional scenarios.