### PR TITLE
Rendering text within the hero card.

### DIFF
--- a/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
@@ -130,10 +130,9 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                                 cardActions.Add(new CardAction("imBack", option.description ?? option.label, value: option.label));
                             }
 
-                            var pickerHeroCard = new HeroCard(buttons: cardActions);
+                            var pickerHeroCard = new HeroCard(text: item.promptMsg ?? item.label,buttons: cardActions);
                             responseActivity = MessageFactory.Attachment(pickerHeroCard.ToAttachment());
-
-                            responseActivity.AsMessageActivity().Text = item.promptMsg ?? item.label;
+                            
                         }
 
                         break;
@@ -173,10 +172,10 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
 
                         booleanCardActions.Add(new CardAction("imBack", title: "Yes", displayText: "Yes", value: "true"));
                         booleanCardActions.Add(new CardAction("imBack", title: "No", displayText: "Yes", value: "false"));
-                        var booleanHeroCard = new HeroCard(buttons: booleanCardActions);
+                        var booleanHeroCard = new HeroCard(text: item.promptMsg ?? item.label,buttons: booleanCardActions);
 
                         responseActivity = MessageFactory.Attachment(booleanHeroCard.ToAttachment());
-                        responseActivity.AsMessageActivity().Text = item.promptMsg ?? item.label;
+                      
                         break;
 
                     case "OutputText":


### PR DESCRIPTION
**Type:**  Improvement
**Description:** If a message contains a text and buttons, it is rendered as 2 different message bubbles in the bot. 
For example: If a message says "Is there anything else? -> Yes/No", each of them are shown as 2 message bubbles. Hence this will be a bad user experience.
**Solution/Fix:** Included the text inside the herocard as one message, rather than constructing seperately. Changes done for picker case and boolean case.