### PR TITLE
Handling null reference exception.

### DIFF
--- a/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
@@ -180,7 +180,7 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                         break;
 
                     case "OutputText":
-                        responseActivity = MessageFactory.Text(item.value.ToString() ?? item.label);
+                        responseActivity = MessageFactory.Text(item.value?.ToString() ?? item.label);
                         break;
 
                     case "OutputImage":
@@ -331,7 +331,7 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                         break;
 
                     default:
-                        responseActivity = MessageFactory.Text(item.value.ToString() ?? item.label);
+                        responseActivity = MessageFactory.Text(item.value?.ToString() ?? item.label);
                         break;
                 }
 


### PR DESCRIPTION
**Type:** Issue
**Description:** When the the response value is null, it cannot convert to String and throws an exception.
**Solution/Fix:** Added null conditional operators for default case and outputText Case to handle null checks.