### PR TITLE
Title is not shown in single link response

### DIFF
--- a/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
@@ -196,14 +196,9 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
 
                         var bodyValue = item.value as BodyValue;
 
-                        var linkHeroCard = new HeroCard(buttons: new List<CardAction>
+                        var linkHeroCard = new HeroCard(text: item.header,buttons: new List<CardAction>
                                 {new CardAction("openUrl", item.label, value: bodyValue.action)});
                         responseActivity = MessageFactory.Attachment(linkHeroCard.ToAttachment());
-
-                        if (!string.IsNullOrEmpty(item.promptMsg))
-                        {
-                            responseActivity.AsMessageActivity().Text = item.promptMsg;
-                        }
 
                         break;
 


### PR DESCRIPTION
**Type:** Issue
**Description:** In the single link response type, title is not shown in the card/message.
**Solution/Fix:** Resolved the issue by adding text inside the hero card, changed item.header to display title for the single link response type.