### PR TITLE
URL is not constructed properly

### DIFF
--- a/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
@@ -113,7 +113,7 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                                     subtitle: option.description,
                                     images: new List<CardImage>()
                                     {
-                                        new CardImage($"https://{_credentials.ServiceNowTenant}{option.attachment}")
+                                        new CardImage($"https://{_credentials.ServiceNowTenant}/{option.attachment}")
                                     },
                                     buttons: new List<CardAction>
                                     {


### PR DESCRIPTION
**Type:** Issue
**Description:** When the images are shown in the carousel, in some scenarios, backslash / is missing in the URL. Hence the URL doesn't work.
**Solution/Fix:** Added one slash in between tenant name and option.attachment.