### PR TITLE
Rich text is not shown

### DIFF
--- a/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
@@ -162,12 +162,7 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                             responseActivity.Attachments.Add(card.ToAttachment());
                         }
                         break;
-                    case "OutputHtml":
-
-                        // We can't render HTML inside of conversations.
-                        responseActivity = MessageFactory.Text(StripTags(item.value.ToString()));
-
-                        break;
+                  
                     case "Boolean":
                         List<CardAction> booleanCardActions = new List<CardAction>();
 
@@ -366,19 +361,6 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
         }
 
         // Crude flattening of HTML content into just it's string content. ServiceNow uses HTML in some scenarios which can't be rendered in most conversational canvases.
-        public static string StripTags(string htmlResponse)
-        {
-            // create whitespace between html elements, so that words do not run together
-            htmlResponse = htmlResponse.Replace(">", "> ");
-
-            var doc = new HtmlAgilityPack.HtmlDocument();
-            doc.LoadHtml(htmlResponse);
-
-            // strip html decoded text from html
-            string text = HttpUtility.HtmlDecode(doc.DocumentNode.InnerText);
-
-            // replace all whitespace with a single space and remove leading and trailing whitespace
-            return Regex.Replace(text, @"\s+", " ").Trim();
-        }
+    
     }
 }


### PR DESCRIPTION
**Type:** Improvement
**Description:** A new response type called OutPutHTML is released in the latest build. With this release, the rich text is not shown and line breaks are missing, displays as a plain text.
**Solution/Fix:** In the old release, this is been handled by deafult switch case. Hence, reverting back to the older case so that it handles the rich text and line breaks. 