### PR TITLE
 Change to UTF8 encoding in the body validation when requesting authorization

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapter.cs
@@ -69,7 +69,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
             }
 
             string body;
-            using (var sr = new StreamReader(httpRequest.Body))
+            using (var sr = new StreamReader(httpRequest.Body, Encoding.UTF8))
             {
                 body = await sr.ReadToEndAsync();
             }

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdRequestAuthorization.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdRequestAuthorization.cs
@@ -10,7 +10,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
     {
         public bool Verify(string _messageBirdSignature, string _signingKey, string _timeStampt, string _requestBody)
         {
-            byte[] _requestBodyByte = Encoding.ASCII.GetBytes(_requestBody);
+            byte[] _requestBodyByte = Encoding.UTF8.GetBytes(_requestBody);
             var requestSigner = new RequestSigner(Encoding.ASCII.GetBytes(_signingKey));
             var request = new Request(_timeStampt, "", _requestBodyByte);
             return requestSigner.IsMatch(_messageBirdSignature, request);


### PR DESCRIPTION
Modifying to UTF8 encoding type in the body validation when requesting authorization to have more compatibility with the character sets of other languages ​​apart from English, since this can generate incompatibility in certain cases such as in #435 .

This change fixed the compatibility problem with Spanish special characters in a project created and deployed with the bot framework composer.