### PR TITLE
ServiceNow Handoff - Fix for Ticket Details are truncating and not wrapping

### DIFF
--- a/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.ServiceNow/ServiceNowController.cs
@@ -271,6 +271,9 @@ namespace Bot.Builder.Community.Components.Handoff.ServiceNow
                                         Items = new List<AdaptiveElement>()
                                         {
                                             new AdaptiveTextBlock(field["fieldValue"]?.ToString())
+                                            {
+                                             Wrap = true
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
Ticket details including Short description & Additional Comments are getting truncating and not wrapping.
Please the below image where Additional Comments fields is getting truncated.
![image](https://user-images.githubusercontent.com/30690070/146012000-99ebedef-c412-4505-8670-16b13c5f4746.png)

In this pull request wrap parameter is added for the Field Values for UI Type OutputCard in ServiceNowHandoffController class.

Thanks Palanikumar.