### PR TITLE
MessageBird API New Request Verification Method and Breaking Changes

### DIFF
--- a/Bot.Builder.Community.Samples.sln
+++ b/Bot.Builder.Community.Samples.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29318.209
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Location Dialog Sample", "samples\Location Dialog Sample\Location Dialog Sample.csproj", "{10BEDE11-C9DE-4B67-9467-4E48272229C6}"
 EndProject
@@ -33,6 +33,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFramework Storage Sample", "samples\EntityFramework Storage Sample\EntityFramework Storage Sample.csproj", "{0EB315B8-7E1E-4F03-ABF1-C258A08640BE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ACS SMS Sample", "samples\ACS SMS Adapter Sample\ACS SMS Sample.csproj", "{6A0A707E-FB59-41C5-8ABA-9AF7A4B68ABF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageBird Adapter Sample", "samples\MessageBird Adapter Sample\MessageBird Adapter Sample.csproj", "{46BA332B-3F41-4DDA-88C0-308AFDA84D88}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -92,10 +94,6 @@ Global
 		{272CCEF9-4DB1-4AC4-9616-CB6E4DDC436F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{272CCEF9-4DB1-4AC4-9616-CB6E4DDC436F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{272CCEF9-4DB1-4AC4-9616-CB6E4DDC436F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BC01A8C4-3FEB-46E8-AE39-D71F5CB7602F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BC01A8C4-3FEB-46E8-AE39-D71F5CB7602F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BC01A8C4-3FEB-46E8-AE39-D71F5CB7602F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BC01A8C4-3FEB-46E8-AE39-D71F5CB7602F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FC26CCC4-9FBA-42F0-8EC9-46C55B6AB145}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FC26CCC4-9FBA-42F0-8EC9-46C55B6AB145}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC26CCC4-9FBA-42F0-8EC9-46C55B6AB145}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -108,6 +106,10 @@ Global
 		{6A0A707E-FB59-41C5-8ABA-9AF7A4B68ABF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A0A707E-FB59-41C5-8ABA-9AF7A4B68ABF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A0A707E-FB59-41C5-8ABA-9AF7A4B68ABF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46BA332B-3F41-4DDA-88C0-308AFDA84D88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46BA332B-3F41-4DDA-88C0-308AFDA84D88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46BA332B-3F41-4DDA-88C0-308AFDA84D88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46BA332B-3F41-4DDA-88C0-308AFDA84D88}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/Bot.Builder.Community.Adapters.MessageBird.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/Bot.Builder.Community.Adapters.MessageBird.csproj
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<PackageTags>microsoft;bot;adapter;messagebird;whatsapp;botframework;botbuilder;bots;msbot-component</PackageTags>
+		<PackageTags>microsoft;bot;adapter;messagebird;whatsapp;botframework;botbuilder;bots</PackageTags>
 		<PackageProjectUrl>https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/master/libraries/Bot.Builder.Community.Adapters.MessageBird</PackageProjectUrl>
 		<Description>Adapter for v4 of the Bot Builder .NET SDK for connecting bots with MessageBird WhatsApp communication channel.</Description>
 		<RepositoryUrl>https://www.github.com/botbuildercommunity/botbuildercommunity-dotnet</RepositoryUrl>

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/Bot.Builder.Community.Adapters.MessageBird.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/Bot.Builder.Community.Adapters.MessageBird.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessageBird" Version="2.1.0" />
+    <PackageReference Include="MessageBird" Version="3.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="$(Bot_Builder_Version)" />
   </ItemGroup>
 

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/Bot.Builder.Community.Adapters.MessageBird.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/Bot.Builder.Community.Adapters.MessageBird.csproj
@@ -4,9 +4,9 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<PackageTags>microsoft;bot;adapter;infobip;sms;botframework;botbuilder;bots</PackageTags>
-		<PackageProjectUrl>https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/master/libraries/Bot.Builder.Community.Adapters.Infobip.MessageBird</PackageProjectUrl>
-		<Description>Adapter for v4 of the Bot Builder .NET SDK to allow for a bot to be used for WhatsApp channel with MessageBird C# SDK.</Description>
+		<PackageTags>microsoft;bot;adapter;messagebird;whatsapp;botframework;botbuilder;bots;msbot-component</PackageTags>
+		<PackageProjectUrl>https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/master/libraries/Bot.Builder.Community.Adapters.MessageBird</PackageProjectUrl>
+		<Description>Adapter for v4 of the Bot Builder .NET SDK for connecting bots with MessageBird WhatsApp communication channel.</Description>
 		<RepositoryUrl>https://www.github.com/botbuildercommunity/botbuildercommunity-dotnet</RepositoryUrl>
 	</PropertyGroup>
 

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapter.cs
@@ -38,8 +38,8 @@ namespace Bot.Builder.Community.Adapters.MessageBird
         public MessageBirdAdapter(MessageBirdAdapterOptions options = null, ILogger logger = null)
         {
             _options = options ?? new MessageBirdAdapterOptions();
-            _logger = logger ?? NullLogger.Instance;
 
+            _logger = logger ?? NullLogger.Instance;
 
             _messageBirdClient = Client.CreateDefault(_options.AccessKey);
             
@@ -137,13 +137,10 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                     }
                 }
                 return Task.FromResult(new ResourceResponse[0]);
-
-
             }
             catch (Exception)
             {
                 return Task.FromResult(new ResourceResponse[0]);
-
             }
         }
     }

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapter.cs
@@ -40,14 +40,9 @@ namespace Bot.Builder.Community.Adapters.MessageBird
             _options = options ?? new MessageBirdAdapterOptions();
             _logger = logger ?? NullLogger.Instance;
 
-            if (_options.UseWhatsAppSandbox)
-            {
-                _messageBirdClient = Client.CreateDefault(_options.AccessKey, features: new Client.Features[] { Client.Features.EnableWhatsAppSandboxConversations });
-            }
-            else
-            {
-                _messageBirdClient = Client.CreateDefault(_options.AccessKey);
-            }
+
+            _messageBirdClient = Client.CreateDefault(_options.AccessKey);
+            
             _requestAuthorization = new MessageBirdRequestAuthorization();
         }
 
@@ -76,7 +71,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                 body = await sr.ReadToEndAsync();
             }
 
-            if (!_requestAuthorization.Verify(httpRequest.Headers["Messagebird-Signature"], _options.SigningKey, httpRequest.Headers["Messagebird-Request-Timestamp"], body))
+            if (!_requestAuthorization.VerifyJWT(httpRequest.Headers["MessageBird-Signature-JWT"], _options.SigningKey, body, _options.MessageBirdWebhookEndpointUrl))
             {
                 httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
                 return;

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapterOptions.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/MessageBirdAdapterOptions.cs
@@ -10,20 +10,20 @@ namespace Bot.Builder.Community.Adapters.MessageBird
 
         }
         public MessageBirdAdapterOptions(IConfiguration configuration)
-            : this(configuration["MessageBirdAccessKey"], configuration["MessageBirdSigningKey"], Convert.ToBoolean(configuration["MessageBirdUseWhatsAppSandbox"]))
+            : this(configuration["MessageBirdAccessKey"], configuration["MessageBirdSigningKey"], configuration["MessageBirdWebhookEndpointUrl"])
         { }
 
-        public MessageBirdAdapterOptions(string accessKey, string signingKey, bool useWhatsAppSandbox)
+        public MessageBirdAdapterOptions(string accessKey, string signingKey, string messageBirdWebhookEndpointUrl)
         {
             AccessKey = accessKey;
             SigningKey = signingKey;
-            UseWhatsAppSandbox = useWhatsAppSandbox;
+            MessageBirdWebhookEndpointUrl = messageBirdWebhookEndpointUrl;
         }
 
         public string AccessKey { get; set; }
 
         public string SigningKey { get; set; }
 
-        public bool UseWhatsAppSandbox { get; set; }
+        public string MessageBirdWebhookEndpointUrl { get; set; }
     }
 }

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/Models/MessageBirdWebhookPayload.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/Models/MessageBirdWebhookPayload.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using MessageBird.Objects.Conversations;
 using System.Text;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
 
 namespace Bot.Builder.Community.Adapters.MessageBird.Models
 {

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
@@ -23,7 +23,7 @@ The adapter currently supports the following scenarios:
 
 ### Sample
 
-Basic sample bot available [here](../../samples/MessageBird%20Adapter%20Sample).
+Basic sample bot available [here](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/develop/samples/MessageBird%20Adapter%20Sample).
 
 ## Usage
 
@@ -36,18 +36,19 @@ Basic sample bot available [here](../../samples/MessageBird%20Adapter%20Sample).
 
 ### Prerequisites
 
-Create a [MessageBird](https://messagebird.com/en/whatsapp/) account and activate WhatsApp Sandbox.
+Create a [MessageBird](https://messagebird.com/en/whatsapp/) account and activate WhatsApp Sandbox or Production.
 Get your [SigningKey](https://dashboard.messagebird.com/en/developers/settings)
 Get your [AccessKey](https://dashboard.messagebird.com/en/developers/access)
 
 ### Set the MessageBird options
 
 At the end of process you will get the following parameters:
-* Signing Key - will be used for requests authentication and authorization 
-* Access Key - endpoint on which messages will be sent
+* SigningKey - will be used for requests authentication and authorization 
+* AccessKey - will be used for MessageBird Conversations API
+* MessageBirdWebhookEndpointUrl - will be used for request verification
 
 
-To authenticate the requests, you will need to configure the Adapter with the Signing Key, Access Key and WhatsApp Sandbox parameter.
+To authenticate the requests, you will need to configure the Adapter with the Signing Key, Access Key and your endpoint for MessageBird webhooks.
 
 You could create in the project an `appsettings.json` file to set the MessageBird options as follows:
 

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
@@ -1,4 +1,4 @@
-﻿# Unofficial MessageBird WhatsApp Adapter for Bot Builder v4 .NET SDK
+﻿﻿# Unofficial MessageBird WhatsApp Adapter for Bot Builder v4 .NET SDK
 
 This project is created by Ahmet Kocadoğan to help Bot Framework community for WhatsApp channel and not related with MessageBird officially.
 
@@ -15,8 +15,9 @@ The adapter currently supports the following scenarios:
 * Send/receive messages with WhatsApp Sandbox
 * Send/receive text messages
 * Send/receive media messages (document, image, video, audio) - Supported formats for media message types available [here](https://developers.facebook.com/docs/whatsapp/api/media/#supported-files)
+* Send/receive stickers - This feature will be supported as soon as MessageBird nuget package add this support. You can check the status of my PR about WhatsApp Sticker messages [here](https://github.com/messagebird/csharp-rest-api/pull/111)
 * Send/receive location messages
-* Verification of incoming MessageBird requests (There is one issue for delivery report webhook verification, MessageBird team is investigating.)
+* Verification of incoming MessageBird requests (New request verification way of MessageBird API via Messagebird-Signature-Jwt header is supported)
 * Receive delivery reports
 * Full incoming request from MessageBird is added to the incoming activity as ChannelData
 
@@ -52,9 +53,9 @@ You could create in the project an `appsettings.json` file to set the MessageBir
 
 ```json
 {
-  "MessageBirdAccessKey": "",
-  "MessageBirdSigningKey": "",
-  "MessageBirdUseWhatsAppSandbox": true
+  "MessageBirdAccessKey": "access_key_that_you_obtained_from_messagebird",
+  "MessageBirdSigningKey": "signing_key_that_you_obtained_from_messagebird",
+  "MessageBirdWebhookEndpointUrl": "your_bot_endpoint_url_for_incoming_messagebird_requests"
 }
 ```
 
@@ -148,3 +149,4 @@ Add the following line into the ***ConfigureServices*** method within your Start
 * [WhatsApp Quickstarts](https://developers.messagebird.com/quickstarts/whatsapp-overview/)
 * [Conversations Documentation](https://developers.messagebird.com/quickstarts/conversations-overview/)
 * [MessageBird Website](https://messagebird.com)
+* [New Request Verification Method](https://developers.messagebird.com/api/#verifying-http-requests)

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
@@ -140,6 +140,82 @@ Add the following line into the ***ConfigureServices*** method within your Start
 
 ```
 
+### Sample code for sending text, image, audio, video, location, file and WhatsApp Sticker (WhatsApp Sticker will be added soon)
+
+## Sending Text Sample Code
+```csharp
+    var reply = MessageFactory.Text("your text here");
+    await turnContext.SendActivityAsync(reply);
+
+```
+
+## Sending Image Sample Code
+```csharp
+    var reply = MessageFactory.Text("Image");
+    Attachment attachment = new Attachment();
+    attachment.Name = "Bot Framework Arcitecture";
+    attachment.ContentType = "image";
+    attachment.ContentUrl = "https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png";
+    reply.Attachments = new List<Attachment>() { attachment };
+    await turnContext.SendActivityAsync(reply);
+
+```
+
+## Sending Audio Sample Code
+```csharp
+    var reply = MessageFactory.Text("Audio");
+    Attachment attachment = new Attachment();
+    attachment.Name = "";
+    attachment.ContentType = "audio";
+    attachment.ContentUrl = "url_of_your_audio";
+    reply.Attachments = new List<Attachment>() { attachment };
+    await turnContext.SendActivityAsync(reply);
+
+```
+
+## Sending Video Sample Code
+```csharp
+    var reply = MessageFactory.Text("Video");
+    Attachment attachment = new Attachment();
+    attachment.Name = "";
+    attachment.ContentType = "video";
+    attachment.ContentUrl = "url_of_your_video";
+    reply.Attachments = new List<Attachment>() { attachment };
+    await turnContext.SendActivityAsync(reply);
+
+```
+
+## Sending Location Sample Code
+```csharp
+    var reply = MessageFactory.Text("Location");
+    reply.Entities = new List<Entity>() { new GeoCoordinates() { Latitude = 41.0572, Longitude = 29.0433 } };
+    await turnContext.SendActivityAsync(reply);
+
+```
+
+## Sending File Sample Code
+```csharp
+    var reply = MessageFactory.Text("File");
+    Attachment attachment = new Attachment();
+    attachment.ContentType = "file";
+    attachment.ContentUrl = "https://qconlondon.com/london-2017/system/files/presentation-slides/microsoft_bot_framework_best_practices.pdf";
+    attachment.Name = "Microsoft Bot Framework Best Practices";
+    reply.Attachments = new List<Attachment>() { attachment };
+    await turnContext.SendActivityAsync(reply);
+
+```
+
+## Sending WhatsApp Sticker Sample Code (This will be added soon)
+```csharp
+    var reply = MessageFactory.Text("WhatsApp Sticker");
+    Attachment attachment = new Attachment();
+    attachment.Name = "";
+    attachment.ContentType = "whatsappsticker";
+    attachment.ContentUrl = "url_of_your_sticker";
+    reply.Attachments = new List<Attachment>() { attachment };
+    await turnContext.SendActivityAsync(reply);
+
+```
 
 
 ### Useful links

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
@@ -80,7 +80,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
             activity.Conversation = new ConversationAccount { IsGroup = false, Id = response.conversation.Id };
             activity.Timestamp = response.message.createdDatetime;
 
-            switch (response.message.type)
+            switch (response.message.type.ToLower())
             {
                 case "audio":
                     {
@@ -150,7 +150,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                         break;
                     }
                 //this will be addes as soon as MessageBird nuget package add support for this message type, my PR is waiting to be merged
-                //case "whatsappSticker":
+                //case "whatsappsticker":
                 //    {
                 //        activity.Attachments = new List<Attachment>
                 //        {

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
@@ -48,7 +48,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                     ChannelId = $"{response.message.platform}-{response.message.channelId}",
                     ChannelData = response,
                     Recipient = new ChannelAccount { Id = response.message.to },
-                    From = new ChannelAccount { Id = response.message.from },
+                    From = new ChannelAccount { Id = response.message.from ?? "you" },
                     Conversation = new ConversationAccount { IsGroup = false, Id = response.conversation.Id },
                     Timestamp = response.message.createdDatetime,
                     Text = null,
@@ -79,35 +79,94 @@ namespace Bot.Builder.Community.Adapters.MessageBird
             activity.From = new ChannelAccount { Id = response.message.from };
             activity.Conversation = new ConversationAccount { IsGroup = false, Id = response.conversation.Id };
             activity.Timestamp = response.message.createdDatetime;
-            if (response.message.type == "text")
+
+            switch (response.message.type)
             {
-                activity.Text = response.message.content.Text;
-                activity.TextFormat = TextFormatTypes.Plain;
-            }
-            else if (response.message.type == "location")
-            {
-                activity.Entities.Add(new GeoCoordinates
-                {
-                    Latitude = response.message.content.Location.Latitude,
-                    Longitude = response.message.content.Location.Longitude
-                });
-            }
-            else if (response.message.type == "image")
-            {
-                var contentType = "";
-                activity.Attachments = new List<Attachment>
-                {
-                    new Attachment
+                case "audio":
                     {
-                        ContentType = contentType,
-                        ContentUrl = response.message.content.Image.Url,
-                        Name = ""// response.message.content.image.caption
+                        activity.Attachments = new List<Attachment>
+                        {
+                            new Attachment
+                            {
+                                ContentType = "audio",
+                                ContentUrl = response.message.content.Audio.Url,
+                                Name = response.message.content.Audio.Caption ?? ""
+                            }
+                        };
+                        break;
                     }
-                };
-            }
-            else
-            {
-                return null;
+                case "file":
+                    {
+                        activity.Attachments = new List<Attachment>
+                        {
+                            new Attachment
+                            {
+                                ContentType = "file",
+                                ContentUrl = response.message.content.File.Url,
+                                Name = response.message.content.File.Caption ?? ""
+                            }
+                        };
+                        break;
+                    }
+                case "image":
+                    {
+                        activity.Attachments = new List<Attachment>
+                        {
+                            new Attachment
+                            {
+                                ContentType = "image",
+                                ContentUrl = response.message.content.Image.Url,
+                                Name = response.message.content.Image.Caption ?? ""
+                            }
+                        };
+                        break;
+                    }
+                case "location":
+                    {
+                        activity.Entities.Add(new GeoCoordinates
+                        {
+                            Latitude = response.message.content.Location.Latitude,
+                            Longitude = response.message.content.Location.Longitude
+                        });
+                        break;
+                    }
+                case "text":
+                    {
+                        activity.Text = response.message.content.Text;
+                        activity.TextFormat = TextFormatTypes.Plain;
+                        break;
+                    }
+                case "video":
+                    {
+                        activity.Attachments = new List<Attachment>
+                        {
+                            new Attachment
+                            {
+                                ContentType = "video",
+                                ContentUrl = response.message.content.Video.Url,
+                                Name = response.message.content.Video.Caption ?? ""
+                            }
+                        };
+                        break;
+                    }
+                //this will be addes as soon as MessageBird nuget package add support for this message type, my PR is waiting to be merged
+                //case "whatsappSticker":
+                //    {
+                //        activity.Attachments = new List<Attachment>
+                //        {
+                //            new Attachment
+                //            {
+                //                ContentType = "whatsappSticker",
+                //                ContentUrl = response.message.content.WhatsAppSticker.Link,
+                //                Name = ""
+                //            }
+                //        };
+                //        break;
+                //    }
+                default:
+                    {
+                        return null;
+                    }
             }
 
             return activity;

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
@@ -67,6 +67,12 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                     message.conversationMessageRequest.Content = new Content() { File = new MediaContent() { Url = attachment.ContentUrl } };
                     message.conversationMessageRequest.Type = ContentType.File;
                 }
+                //this will be addes as soon as MessageBird nuget package add support for this message type, my PR is waiting to be merged
+                //else if (contentType.Contains("whatsappSticker"))
+                //{
+                //    message.conversationMessageRequest.Content = new Content() { File = new WhatsAppStickerContent() { Link = attachment.ContentUrl } };
+                //    message.conversationMessageRequest.Type = ContentType.WhatsAppSticker;
+                //}
 
                 messages.Add(message);
             }
@@ -87,9 +93,7 @@ IList<MessageBirdSendMessagePayload> messages)
 
                     messages.Add(message);
                 }
-
             }
-
         }
 
         private static MessageBirdSendMessagePayload CreateMessage(IMessageActivity activity)

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
@@ -47,33 +47,40 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                 var message = CreateMessage(activity);
 
                 var contentType = attachment.ContentType.ToLower();
-                if (contentType.Contains("image"))
-                {
-                    message.conversationMessageRequest.Content = new Content() { Image = new MediaContent() { Url = attachment.ContentUrl } };
-                    message.conversationMessageRequest.Type = ContentType.Image;
-                }
-                else if (contentType.Contains("video"))
-                {
-                    message.conversationMessageRequest.Content = new Content() { Video = new MediaContent() { Url = attachment.ContentUrl } };
-                    message.conversationMessageRequest.Type = ContentType.Video;
-                }
-                else if (contentType.Contains("audio"))
-                {
-                    message.conversationMessageRequest.Content = new Content() { Audio = new MediaContent() { Url = attachment.ContentUrl } };
-                    message.conversationMessageRequest.Type = ContentType.Audio;
-                }
-                else
-                {
-                    message.conversationMessageRequest.Content = new Content() { File = new MediaContent() { Url = attachment.ContentUrl } };
-                    message.conversationMessageRequest.Type = ContentType.File;
-                }
-                //this will be addes as soon as MessageBird nuget package add support for this message type, my PR is waiting to be merged
-                //else if (contentType.Contains("whatsappSticker"))
-                //{
-                //    message.conversationMessageRequest.Content = new Content() { File = new WhatsAppStickerContent() { Link = attachment.ContentUrl } };
-                //    message.conversationMessageRequest.Type = ContentType.WhatsAppSticker;
-                //}
 
+                switch (contentType)
+                {
+                    case "image":
+                        {
+                            message.conversationMessageRequest.Content = new Content() { Image = new MediaContent() { Url = attachment.ContentUrl } };
+                            message.conversationMessageRequest.Type = ContentType.Image;
+                            break;
+                        }
+                    case "video":
+                        {
+                            message.conversationMessageRequest.Content = new Content() { Video = new MediaContent() { Url = attachment.ContentUrl } };
+                            message.conversationMessageRequest.Type = ContentType.Video;
+                            break;
+                        }
+                    case "audio":
+                        {
+                            message.conversationMessageRequest.Content = new Content() { Audio = new MediaContent() { Url = attachment.ContentUrl } };
+                            message.conversationMessageRequest.Type = ContentType.Audio;
+                            break;
+                        }
+                    //case "whatsappSticker":
+                    //    {
+                    //        message.conversationMessageRequest.Content = new Content() { File = new WhatsAppStickerContent() { Link = attachment.ContentUrl } };
+                    //        message.conversationMessageRequest.Type = ContentType.WhatsAppSticker;
+                    //        break;
+                    //    }
+                    default:
+                        {
+                            message.conversationMessageRequest.Content = new Content() { File = new MediaContent() { Url = attachment.ContentUrl } };
+                            message.conversationMessageRequest.Type = ContentType.File;
+                            break;
+                        }
+                }
                 messages.Add(message);
             }
         }

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
@@ -88,7 +88,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                             message.conversationMessageRequest.Type = ContentType.Audio;
                             break;
                         }
-                    //case "whatsappSticker":
+                    //case "whatsappsticker":
                     //    {
                     //        message.conversationMessageRequest.Content = new Content() 
                     //        { 
@@ -154,6 +154,5 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                 }
             };
         }
-
     }
 }

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
@@ -32,8 +32,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
 
             return messages;
         }
-        private static void HandleText(IMessageActivity activity,
-    IList<MessageBirdSendMessagePayload> messages)
+        private static void HandleText(IMessageActivity activity, IList<MessageBirdSendMessagePayload> messages)
         {
             var message = CreateMessage(activity);
             message.conversationMessageRequest.Content = new Content() { Text = activity.Text };
@@ -51,32 +50,66 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                 switch (contentType)
                 {
                     case "image":
-                        {
-                            message.conversationMessageRequest.Content = new Content() { Image = new MediaContent() { Url = attachment.ContentUrl } };
+                        { 
+                            message.conversationMessageRequest.Content = new Content() 
+                            { 
+                                Image = new MediaContent() 
+                                { 
+                                    Url = attachment.ContentUrl,
+                                    Caption = attachment.Name ?? ""
+                                } 
+                            };
                             message.conversationMessageRequest.Type = ContentType.Image;
                             break;
                         }
                     case "video":
                         {
-                            message.conversationMessageRequest.Content = new Content() { Video = new MediaContent() { Url = attachment.ContentUrl } };
+                            message.conversationMessageRequest.Content = new Content() 
+                            { 
+                                Video = new MediaContent() 
+                                { 
+                                    Url = attachment.ContentUrl,
+                                    Caption = attachment.Name ?? ""
+                                } 
+                            };
                             message.conversationMessageRequest.Type = ContentType.Video;
                             break;
                         }
                     case "audio":
                         {
-                            message.conversationMessageRequest.Content = new Content() { Audio = new MediaContent() { Url = attachment.ContentUrl } };
+                            message.conversationMessageRequest.Content = new Content() 
+                            { 
+                                Audio = new MediaContent() 
+                                { 
+                                    Url = attachment.ContentUrl,
+                                    Caption = attachment.Name ?? ""
+                                } 
+                            };
                             message.conversationMessageRequest.Type = ContentType.Audio;
                             break;
                         }
                     //case "whatsappSticker":
                     //    {
-                    //        message.conversationMessageRequest.Content = new Content() { File = new WhatsAppStickerContent() { Link = attachment.ContentUrl } };
+                    //        message.conversationMessageRequest.Content = new Content() 
+                    //        { 
+                    //            File = new WhatsAppStickerContent(
+                    //            { 
+                    //                Link = attachment.ContentUrl 
+                    //            } 
+                    //        };
                     //        message.conversationMessageRequest.Type = ContentType.WhatsAppSticker;
                     //        break;
                     //    }
                     default:
                         {
-                            message.conversationMessageRequest.Content = new Content() { File = new MediaContent() { Url = attachment.ContentUrl } };
+                            message.conversationMessageRequest.Content = new Content() 
+                            { 
+                                File = new MediaContent() 
+                                { 
+                                    Url = attachment.ContentUrl,
+                                    Caption = attachment.Name ?? ""
+                                } 
+                            };
                             message.conversationMessageRequest.Type = ContentType.File;
                             break;
                         }
@@ -85,8 +118,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
             }
         }
 
-        private static void HandleEntities(IMessageActivity activity,
-IList<MessageBirdSendMessagePayload> messages)
+        private static void HandleEntities(IMessageActivity activity, IList<MessageBirdSendMessagePayload> messages)
         {
             foreach (var entity in activity.Entities)
             {
@@ -95,7 +127,14 @@ IList<MessageBirdSendMessagePayload> messages)
                 {
                     var message = CreateMessage(activity);
 
-                    message.conversationMessageRequest.Content = new Content() { Location = new LocationContent() { Latitude = (float)location.Latitude, Longitude = (float)location.Longitude } };
+                    message.conversationMessageRequest.Content = new Content() 
+                    { 
+                        Location = new LocationContent() 
+                        { 
+                            Latitude = (float)location.Latitude, 
+                            Longitude = (float)location.Longitude 
+                        } 
+                    };
                     message.conversationMessageRequest.Type = ContentType.Location;
 
                     messages.Add(message);

--- a/libraries/Bot.Builder.Community.Components.Adapters.MessageBird/Schemas/BotBuilderCommunity.MessageBirdAdapter.schema
+++ b/libraries/Bot.Builder.Community.Components.Adapters.MessageBird/Schemas/BotBuilderCommunity.MessageBirdAdapter.schema
@@ -1,24 +1,24 @@
 {
   "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
   "$role": "implements(Microsoft.IAdapter)",
-  "title": "MessageBird Connection",
-  "description": "Connects a bot to MessageBird WhatsApp.",
+  "title": "MessageBird WhatsApp Connection",
+  "description": "Connects a bot to MessageBird WhatsApp channel.",
   "type": "object",
   "properties": {
     "AccessKey": {
       "type": "string",
       "title": "Access Key",
-      "description": "Endpoint on which messages will be sent."
+      "description": "Your access key to interact with MessageBird API."
     },
     "SigningKey": {
       "type": "string",
       "title": "Signing Key",
-      "description": "Signing Key for requests authentication and authorization."
+      "description": "Signing Key for incoming request verification."
     },
-    "UseWhatsAppSandbox": {
-      "type": "boolean",
-      "title": "UseWhatsAppSandbox",
-      "description": "Use WhatsApp Sandbox."
+    "MessageBirdWebhookEndpointUrl": {
+      "type": "string",
+      "title": "MessageBird Endpoint URL",
+      "description": "Your bot endpoint to receive MessageBird webhooks. Required for incoming request verification. Add full URL like https://www.yourdomain.com/api/messagebird"
     },
     "route": {
       "type": "string",
@@ -36,6 +36,6 @@
   "required": [
     "AccessKey",
     "SigningKey",
-    "UseWhatsAppSandbox"
+    "MessageBirdWebhookEndpointUrl"
   ]
 }

--- a/libraries/Bot.Builder.Community.Components.Adapters.MessageBird/Schemas/BotBuilderCommunity.MessageBirdAdapter.uischema
+++ b/libraries/Bot.Builder.Community.Components.Adapters.MessageBird/Schemas/BotBuilderCommunity.MessageBirdAdapter.uischema
@@ -2,12 +2,12 @@
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
   "form": {
     "label": "MessageBirdAdapter connection",
-    "description": "Connects a bot to MessageBird whatsApp.",
-    "helpLink": "https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/feature/packages-preview/libraries/Bot.Builder.Community.Adapters.Zoom/Component/README.md",
+    "description": "Connects a bot to MessageBird WhatsApp channel.",
+    "helpLink": "https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md",
     "order": [
       "AccessKey",
       "SigningKey",
-      "UseWhatsAppSandbox",
+      "MessageBirdWebhookEndpointUrl",
       "*"
     ],
     "hidden": [

--- a/samples/MessageBird Adapter Sample/Bots/EchoBot.cs
+++ b/samples/MessageBird Adapter Sample/Bots/EchoBot.cs
@@ -36,7 +36,7 @@ namespace MessageBird_Adapter_Sample.Bots
                     {
                         var reply = MessageFactory.Text("File");
                         Attachment attachment = new Attachment();
-                        attachment.ContentType = "application/pdf";
+                        attachment.ContentType = "file";
                         attachment.ContentUrl = "https://qconlondon.com/london-2017/system/files/presentation-slides/microsoft_bot_framework_best_practices.pdf";
                         attachment.Name = "Microsoft Bot Framework Best Practices";
                         reply.Attachments = new List<Attachment>() { attachment };
@@ -48,7 +48,7 @@ namespace MessageBird_Adapter_Sample.Bots
                         var reply = MessageFactory.Text("Image");
                         Attachment attachment = new Attachment();
                         attachment.Name = "Bot Framework Arcitecture";
-                        attachment.ContentType = "image/png";
+                        attachment.ContentType = "image";
                         attachment.ContentUrl = "https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png";
                         reply.Attachments = new List<Attachment>() { attachment };
                         await turnContext.SendActivityAsync(reply);

--- a/samples/MessageBird Adapter Sample/Bots/EchoBot.cs
+++ b/samples/MessageBird Adapter Sample/Bots/EchoBot.cs
@@ -47,7 +47,7 @@ namespace MessageBird_Adapter_Sample.Bots
                     {
                         var reply = MessageFactory.Text("Image");
                         Attachment attachment = new Attachment();
-                        attachment.Name = "architecture-resize.png";
+                        attachment.Name = "Bot Framework Arcitecture";
                         attachment.ContentType = "image/png";
                         attachment.ContentUrl = "https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png";
                         reply.Attachments = new List<Attachment>() { attachment };

--- a/samples/MessageBird Adapter Sample/appsettings.json
+++ b/samples/MessageBird Adapter Sample/appsettings.json
@@ -3,5 +3,5 @@
   "MicrosoftAppPassword": "",
   "MessageBirdAccessKey": "",
   "MessageBirdSigningKey": "",
-  "MessageBirdUseWhatsAppSandbox": true
+  "MessageBirdWebhookEndpointUrl": ""
 }


### PR DESCRIPTION
issue #466

This update adds the new and suggested way of request verification with MessageBird API.

MessageBird NuGet package is updated to the version 3.2.0
Removed old request verification method and replaced it with new request verification method.
Required code for WhatsApp sticker messages has been added but commented because MessageBird Nuget package 3.2.0 does not support it yet, my PR is waiting to be reviewed and when it is merged, i'll uncomment and update the adapter code.
See : https://github.com/messagebird/csharp-rest-api/pull/111

Breaking Changes:

MessageBirdUseWhatsAppSandbox parameter is removed due to the changes in MessageBird C# NuGet package. This is no longer needed according to MessageBird. See https://github.com/messagebird/csharp-rest-api/pull/87

`public string MessageBirdWebhookEndpointUrl { get; set; }` is added to AdapterOptions and should be added in appsettings.json file. This parameter should be the endpoint url for receiving MessageBird WhatsApp messages, like https://www.botdomainname.com/api/messagebird . This url is being used in the request verification method.
For more info , see https://developers.messagebird.com/api/#verifying-http-requests

@rvinothrajendran fyi. You can update the component for Composer according to these changes. Thank you.