### PR TITLE
Issue with channel id's that contains - character

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
@@ -45,7 +45,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                 {
                     Type = ActivityTypes.Event,
                     Id = response.message.id,
-                    ChannelId = $"{response.message.platform}-{response.message.channelId}",
+                    ChannelId = $"{response.message.platform}#{response.message.channelId}",
                     ChannelData = response,
                     Recipient = new ChannelAccount { Id = response.message.to },
                     From = new ChannelAccount { Id = response.message.from ?? "you" },
@@ -73,7 +73,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
 
             activity.Type = ActivityTypes.Message;
             activity.Id = response.message.id;
-            activity.ChannelId = $"{response.message.platform}-{response.message.channelId}";
+            activity.ChannelId = $"{response.message.platform}#{response.message.channelId}";
             activity.ChannelData = response;
             activity.Recipient = new ChannelAccount { Id = response.message.to };
             activity.From = new ChannelAccount { Id = response.message.from };

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
@@ -150,7 +150,7 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                 conversationMessageRequest = new ConversationMessageSendRequest()
                 {
                     ConversationId = activity.Conversation.Id,
-                    ChannelId = activity.ChannelId.Split('-')[1]
+                    ChannelId = activity.ChannelId.Split('#')[1]
                 }
             };
         }


### PR DESCRIPTION
Library joins channel name and channel id with - character when a webhook request comes and split and use that value for sending messages back. For channel names contains - character, bot does not respond. I changed the character to split to # so this won't be an issue after update.

This PR should be released as soon as we can because this is a show stopper for the people who has channel id's with - character.