### PR TITLE
Bug fix for mapping of item in reaction_event

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Slack/Model/EventType.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Slack/Model/EventType.cs
@@ -16,11 +16,11 @@ namespace Bot.Builder.Community.Adapters.Slack.Model
 
         public string Ts { get; set; }
 
-        public JObject Item { get; } = new JObject();
+        public JObject Item { get; set;}
 
         [JsonProperty(PropertyName = "event_ts")]
         public string EventTs { get; set; }
-
+        [JsonProperty(PropertyName = "channel")]
         public string Channel { get; set; }
 
         [JsonProperty(PropertyName = "channel_id")]
@@ -34,5 +34,7 @@ namespace Bot.Builder.Community.Adapters.Slack.Model
 
         [JsonExtensionData(ReadData = true, WriteData = true)]
         public IDictionary<string, JToken> AdditionalProperties { get; } = new Dictionary<string, JToken>();
+
+        public JObject Original {get; set;}
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Slack.Tests/Files/MessageBody.json
+++ b/tests/Bot.Builder.Community.Adapters.Slack.Tests/Files/MessageBody.json
@@ -11,7 +11,12 @@
     "team": "teamId",
     "channel": "channelId",
     "event_ts": "1568915625.001000",
-    "channel_type": "im"
+    "channel_type": "im",
+    "item": {
+      "type": "message",
+      "channel": "test",
+      "ts": "1641484950.002700"
+    }
   },
   "type": "event_callback",
   "event_id": "eventId",


### PR DESCRIPTION
RE: https://github.com/microsoft/botbuilder-dotnet/issues/6220

The reaction_added event was missing the item object. Made code changes and tested out locally to ensure the item object is inside the event.