### PR TITLE
Webex Adapter: Changing encoding from ASCII to UTF8 to support extended charset

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Webex/WebexClientWrapper.cs
@@ -136,11 +136,12 @@ namespace Bot.Builder.Community.Adapters.Webex
             http.PreAuthenticate = true;
             http.Headers.Add("Authorization", "Bearer " + Options.WebexAccessToken);
             http.Accept = "application/json";
-            http.ContentType = "application/json";
+            http.ContentType = "application/json" +
+                "; charset=utf-8";
             http.Method = "POST";
 
             var parsedContent = JsonConvert.SerializeObject(request);
-            var encoding = new ASCIIEncoding();
+            var encoding = new UTF8Encoding();
             var bytes = encoding.GetBytes(parsedContent);
 
             var newStream = await http.GetRequestStreamAsync().ConfigureAwait(false);


### PR DESCRIPTION
Hi guys,

I'm currently trying the integration of the Webex adapter in a new bot project. I noticed a difference in the display between normal messages and the adaptive cards. Specifically, for me, it was the representation of German special characters (ä, ö, ü, ß) as well as emojis. After a long search and manual queries against the Webex API, I noticed the explicit ASCII encoding. This is only used by the adapter for messages with attachments. I suggest changing the encoding to UTF-8 and explicitly specifying the type in the HTTP header.

The tests all run through, however, this particular case does not appear to be under test (yet). I have applied the changes in my own deployment and the adaptive cards are now rendering correctly in Webex.

Best Regards,
Bastian

P.S. This is my first contribution to a public repository. Any feedback is highly appreciated 😊