### PR TITLE
Webex Adapter: Adding support for Markdown and set default text format to Markdown instead of plain text

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Webex/Bot.Builder.Community.Adapters.Webex.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Webex/Bot.Builder.Community.Adapters.Webex.csproj
@@ -36,4 +36,8 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="$(Bot_Builder_Version)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Bot.Builder.Community.Adapters.Shared\Bot.Builder.Community.Adapters.Shared.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/libraries/Bot.Builder.Community.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Webex/WebexAdapter.cs
@@ -86,6 +86,15 @@ namespace Bot.Builder.Community.Adapters.Webex
                     string recipientId;
                     var target = MessageTarget.PersonId;
 
+                    // map text format
+                    if (activity.TextFormat == TextFormatTypes.Xml)
+                    {
+                        _logger.LogTrace($"Unsupported TextFormat: '{activity.TextFormat}'. Only TextFormat of types 'Plain' or 'Markdown' are supported.");
+                        activity.TextFormat = TextFormatTypes.Plain;
+                    }
+
+                    var messageType = activity.TextFormat == TextFormatTypes.Plain ? MessageTextType.Text : MessageTextType.Markdown;
+
                     if (activity.Conversation?.Id != null)
                     {
                         recipientId = activity.Conversation.Id;
@@ -110,7 +119,7 @@ namespace Bot.Builder.Community.Adapters.Webex
                     {
                         if (activity.Attachments[0].ContentType == "application/vnd.microsoft.card.adaptive")
                         {
-                            responseId = await _webexClient.CreateMessageWithAttachmentsAsync(recipientId, activity.Text, activity.Attachments, MessageTextType.Text, target, cancellationToken).ConfigureAwait(false);
+                            responseId = await _webexClient.CreateMessageWithAttachmentsAsync(recipientId, activity.Text, activity.Attachments, messageType, target, cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
@@ -122,13 +131,13 @@ namespace Bot.Builder.Community.Adapters.Webex
                                 files.Add(file);
                             }
 
-                            responseId = await _webexClient.CreateMessageAsync(recipientId, activity.Text, files.Count > 0 ? files : null, MessageTextType.Text, target, cancellationToken).ConfigureAwait(false);
+                            responseId = await _webexClient.CreateMessageAsync(recipientId, activity.Text, files.Count > 0 ? files : null, messageType, target, cancellationToken).ConfigureAwait(false);
                         }
                     }
                     else
                     {
                         responseId = await _webexClient
-                            .CreateMessageAsync(recipientId, activity.Text, target: target, cancellationToken: cancellationToken)
+                            .CreateMessageAsync(recipientId, activity.Text, messageType: messageType, target: target, cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
 

--- a/libraries/Bot.Builder.Community.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Webex/WebexClientWrapper.cs
@@ -85,7 +85,7 @@ namespace Bot.Builder.Community.Adapters.Webex
         /// <param name="target">Target for the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The created message id.</returns>
-        public virtual async Task<string> CreateMessageAsync(string recipient, string text, IList<Uri> files = null, MessageTextType messageType = MessageTextType.Text, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
+        public virtual async Task<string> CreateMessageAsync(string recipient, string text, IList<Uri> files = null, MessageTextType messageType = MessageTextType.Markdown, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
         {
             var webexResponse = await _api.CreateMessageAsync(recipient, text, files, target, messageType, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -113,7 +113,7 @@ namespace Bot.Builder.Community.Adapters.Webex
         /// <param name="target">Target for the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The created message id.</returns>
-        public virtual async Task<string> CreateMessageWithAttachmentsAsync(string recipient, string textOrMarkdown, IList<Attachment> attachments, MessageTextType messageType = MessageTextType.Text, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
+        public virtual async Task<string> CreateMessageWithAttachmentsAsync(string recipient, string textOrMarkdown, IList<Attachment> attachments, MessageTextType messageType = MessageTextType.Markdown, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
         {
             Message result;
 

--- a/libraries/Bot.Builder.Community.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Webex/WebexClientWrapper.cs
@@ -107,13 +107,13 @@ namespace Bot.Builder.Community.Adapters.Webex
         /// Creates a message with attachments.
         /// </summary>
         /// <param name="recipient">PersonId, email or roomId of the message.</param>
-        /// <param name="text">Text of the message.</param>
+        /// <param name="textOrMarkdown">Text or markdown of the message.</param>
         /// <param name="attachments">List of attachments attached to the message.</param>
         /// <param name="messageType">Type of the message. It can be Text or Markdown.</param>
         /// <param name="target">Target for the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The created message id.</returns>
-        public virtual async Task<string> CreateMessageWithAttachmentsAsync(string recipient, string text, IList<Attachment> attachments, MessageTextType messageType = MessageTextType.Text, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
+        public virtual async Task<string> CreateMessageWithAttachmentsAsync(string recipient, string textOrMarkdown, IList<Attachment> attachments, MessageTextType messageType = MessageTextType.Text, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
         {
             Message result;
 
@@ -124,11 +124,21 @@ namespace Bot.Builder.Community.Adapters.Webex
                 attachmentsContent.Add(attach.Content);
             }
 
+            var text = textOrMarkdown ?? string.Empty;
+            string markdown = null;
+            
+            if (!string.IsNullOrEmpty(textOrMarkdown) && messageType == MessageTextType.Markdown)
+            {
+                markdown = textOrMarkdown;
+                text = Shared.MarkdownToPlaintextRenderer.Render(textOrMarkdown);
+            }
+
             var request = new WebexMessageRequest
             {
                 RoomId = target == MessageTarget.SpaceId ? recipient : null,
-                ToPersonId = target == MessageTarget.SpaceId ? null : recipient,
-                Text = text ?? string.Empty,
+                ToPersonId = target == MessageTarget.SpaceId ? null : recipient,                
+                Text = text,
+                Markdown = markdown,                                
                 Attachments = attachmentsContent.Count > 0 ? attachmentsContent : null,
             };
 

--- a/libraries/Bot.Builder.Community.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Webex/WebexClientWrapper.cs
@@ -126,7 +126,7 @@ namespace Bot.Builder.Community.Adapters.Webex
 
             var text = textOrMarkdown ?? string.Empty;
             string markdown = null;
-            
+
             if (!string.IsNullOrEmpty(textOrMarkdown) && messageType == MessageTextType.Markdown)
             {
                 markdown = textOrMarkdown;
@@ -136,9 +136,9 @@ namespace Bot.Builder.Community.Adapters.Webex
             var request = new WebexMessageRequest
             {
                 RoomId = target == MessageTarget.SpaceId ? recipient : null,
-                ToPersonId = target == MessageTarget.SpaceId ? null : recipient,                
+                ToPersonId = target == MessageTarget.SpaceId ? null : recipient,
                 Text = text,
-                Markdown = markdown,                                
+                Markdown = markdown,
                 Attachments = attachmentsContent.Count > 0 ? attachmentsContent : null,
             };
 


### PR DESCRIPTION
This PR addresses an issue regarding Markdown-formatted messages with the Webex adapter #479. The current implementation calls the Webex API to create messages and supplies the content always under `text` which will result in a plain text message. However, we can call the same method and use `markdown` to supply a formatted message. In this case, we can additionally provide a plain text message for clients that are not able to render Markdown utilizing [`MarkdownToPlaintextRenderer`](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/cccc14f6f598f7ddf493ebbe42e4ba40126d19fd/libraries/Bot.Builder.Community.Adapters.Shared/MarkdownToPlaintextRenderer.cs#L10) (see also [API documentation](https://developer.webex.com/docs/api/v1/messages/create-a-message))

Moreover, I suggest changing the default behaviour to expect Markdown-formatted messages to match the default `IMessageActivity.TextFormat`.