### PR TITLE
Add OptOutType property for subscription management.

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Twilio/TwilioMessage.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twilio/TwilioMessage.cs
@@ -152,5 +152,11 @@ namespace Bot.Builder.Community.Adapters.Twilio
         /// </summary>
         /// <value>The type of event, e.g. "onMessageAdd", "onMessageAdded", "onConversationAdd".</value>
         public string EventType { get; set; }
-    }
+
+        /// <summary>
+        /// Gets or sets Twilio Opt-In / Opt-Out type when command matches configured keywords.
+        /// </summary>
+        /// <value>null, "START", "STOP", or "HELP".</value>
+        public string OptOutType { get; set; }
+  }
 }


### PR DESCRIPTION
Adds new property _OptOutType_ to _TwilioMessage_ class.  

This property is set by Twilio API when an incoming message matches one of the configured subscription keywords.  If there is a match, Twilio will set this value to either START, STOP, or HELP.

see https://www.twilio.com/docs/messaging/services/tutorials/advanced-opt-out#keeping-track-of-your-users-status for description.