### PR TITLE
fixed "Microsoft.MarkedNet" package dependency issue

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Shared/Bot.Builder.Community.Adapters.Shared.csproj
+++ b/libraries/Bot.Builder.Community.Adapters.Shared/Bot.Builder.Community.Adapters.Shared.csproj
@@ -6,10 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="2.1.0" />
+    <PackageReference Include="AdaptiveCards" Version="2.7.3" />
     <PackageReference Include="Microsoft.Bot.Schema" Version="$(Bot_Builder_Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.MarkedNet" Version="1.0.13" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
   </ItemGroup>
 

--- a/libraries/Bot.Builder.Community.Components.Adapters.GoogleBusiness.Core/Bot.Builder.Community.Components.Adapters.GoogleBusiness.Core.csproj
+++ b/libraries/Bot.Builder.Community.Components.Adapters.GoogleBusiness.Core/Bot.Builder.Community.Components.Adapters.GoogleBusiness.Core.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="2.7.1" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.13.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
Adaptive Card team merged "Microsoft.MarkedNet" package into their package after verison 2.6.0. The dependency in Bot.Builder.Community.Adapters.Shared.csproj will leads reference issue. 

Upgade adaptive card version and remove reference of "Microsoft.MarkedNet" to solve the issue