### PR TITLE
Add WhatsApp Sticker Support

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/README.md
@@ -206,7 +206,7 @@ Add the following line into the ***ConfigureServices*** method within your Start
 
 ```
 
-## Sending WhatsApp Sticker Sample Code (This will be added soon)
+## Sending WhatsApp Sticker Sample Code
 ```csharp
     var reply = MessageFactory.Text("WhatsApp Sticker");
     Attachment attachment = new Attachment();

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToActivityConverter.cs
@@ -150,19 +150,19 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                         break;
                     }
                 //this will be addes as soon as MessageBird nuget package add support for this message type, my PR is waiting to be merged
-                //case "whatsappsticker":
-                //    {
-                //        activity.Attachments = new List<Attachment>
-                //        {
-                //            new Attachment
-                //            {
-                //                ContentType = "whatsappSticker",
-                //                ContentUrl = response.message.content.WhatsAppSticker.Link,
-                //                Name = ""
-                //            }
-                //        };
-                //        break;
-                //    }
+                case "whatsappsticker":
+                   {
+                       activity.Attachments = new List<Attachment>
+                       {
+                           new Attachment
+                           {
+                               ContentType = "whatsappSticker",
+                               ContentUrl = response.message.content.WhatsAppSticker.Link,
+                               Name = ""
+                           }
+                       };
+                       break;
+                   }
                 default:
                     {
                         return null;

--- a/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
+++ b/libraries/Bot.Builder.Community.Adapters.MessageBird/ToMessageBirdConverter.cs
@@ -88,18 +88,18 @@ namespace Bot.Builder.Community.Adapters.MessageBird
                             message.conversationMessageRequest.Type = ContentType.Audio;
                             break;
                         }
-                    //case "whatsappsticker":
-                    //    {
-                    //        message.conversationMessageRequest.Content = new Content() 
-                    //        { 
-                    //            File = new WhatsAppStickerContent(
-                    //            { 
-                    //                Link = attachment.ContentUrl 
-                    //            } 
-                    //        };
-                    //        message.conversationMessageRequest.Type = ContentType.WhatsAppSticker;
-                    //        break;
-                    //    }
+                    case "whatsappsticker":
+                       {
+                           message.conversationMessageRequest.Content = new Content() 
+                           { 
+                               File = new WhatsAppStickerContent(
+                               { 
+                                   Link = attachment.ContentUrl 
+                               } 
+                           };
+                           message.conversationMessageRequest.Type = ContentType.WhatsAppSticker;
+                           break;
+                       }
                     default:
                         {
                             message.conversationMessageRequest.Content = new Content() 


### PR DESCRIPTION
In previous commits, i already added WhatsApp sticker support but commented the code because MessageBird C# SDK was not ready for sending and receiving stickers. Now it is ready and WhatsApp sticker support can be added.