### PR TITLE
Fix an issue with LivePerson skills not being passed correctly to the LP API.

### DIFF
--- a/libraries/Bot.Builder.Community.Components.Handoff.LivePerson/LivePersonConnector.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.LivePerson/LivePersonConnector.cs
@@ -45,7 +45,6 @@ namespace Bot.Builder.Community.Components.Handoff.LivePerson
                         kind = "req",
                         id = "2,",
                         type = "cm.ConsumerRequestConversation",
-                        
                         body = new Body { 
                             brandId = account,
                             skillId = skill

--- a/libraries/Bot.Builder.Community.Components.Handoff.LivePerson/LivePersonConnector.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.LivePerson/LivePersonConnector.cs
@@ -45,8 +45,11 @@ namespace Bot.Builder.Community.Components.Handoff.LivePerson
                         kind = "req",
                         id = "2,",
                         type = "cm.ConsumerRequestConversation",
-                        skillId = skill,
-                        body = new Body { brandId = account }
+                        
+                        body = new Body { 
+                            brandId = account,
+                            skillId = skill
+                        }
                     },
             };
 

--- a/libraries/Bot.Builder.Community.Components.Handoff.LivePerson/Models/Body.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.LivePerson/Models/Body.cs
@@ -4,5 +4,6 @@
     {
         public Authenticateddata authenticatedData { get; set; }
         public string brandId { get; set; }
+        public string skillId { get; set; }
     }
 }

--- a/libraries/Bot.Builder.Community.Components.Handoff.LivePerson/Models/Conversation.cs
+++ b/libraries/Bot.Builder.Community.Components.Handoff.LivePerson/Models/Conversation.cs
@@ -5,7 +5,6 @@
         public string kind { get; set; }
         public string id { get; set; }
         public string type { get; set; }
-        public string skillId { get; set; }
         public Body body { get; set; }
     }
 }


### PR DESCRIPTION
This is a small patch that moves the skillId into the body of the Conversation request, as per LivePerson's documentation. This should fix not being able to properly specify the skill in a handoff.