### PR TITLE
Changed AzureAdAuthentication documentation to refer correct variable

### DIFF
--- a/libraries/Bot.Builder.Community.Middleware.AzureAdAuthentication/README.md
+++ b/libraries/Bot.Builder.Community.Middleware.AzureAdAuthentication/README.md
@@ -50,7 +50,7 @@ public class InMemoryAuthTokenStorage : IAuthTokenStorage
 
     public void SaveConfiguration(ConversationAuthToken token)
     {
-        InMemoryDictionary[state.Id] = token;
+        InMemoryDictionary[token.Id] = token;
     }
 }
 ```


### PR DESCRIPTION
Changed the key from `state.Id` to `token.Id` for correct variable reference.